### PR TITLE
Almost-complete minimum viable plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If everything checks out, the bundle for cargo should be available in the `targe
 
 #### Run as a Docker container
 
-`docker run -d -p 8081:8081 --name nexus nexus-repository-cargo`
+`docker run -d -p 8081:8081 --name nexus-repository-cargo nexus-repository-cargo`
 
 For further information like how to persist volumes check out [the GitHub repo for our official image](https://github.com/sonatype/docker-nexus3).
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>nexus-rapture</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.eclipse.jgit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
       <artifactId>nexus-rapture</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>5.0.1.201806211838-r</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -69,6 +75,18 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.20</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Embed-Dependency>*;scope=compile|runtime;inline=true;artifactId=!slf4j*</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
       <artifactId>nexus-repository</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-rapture</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -38,6 +44,19 @@
           <target>1.8</target>
           <compilerId>javac</compilerId>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.sonatype.nexus.buildsupport</groupId>
+        <artifactId>extjs-maven-plugin</artifactId>
+        <configuration>
+          <namespace>NX.cargo</namespace>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>yuicompressor-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>5.0.1.201806211838-r</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.vdurmont</groupId>
+      <artifactId>semver4j</artifactId>
+      <version>2.2.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRecipeSupport.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRecipeSupport.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.sonatype.nexus.plugins.cargo.security.CargoSecurityFacet;
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.RecipeSupport;
+import org.sonatype.nexus.repository.Type;
+import org.sonatype.nexus.repository.attributes.AttributesFacet;
+import org.sonatype.nexus.repository.cache.NegativeCacheFacet;
+import org.sonatype.nexus.repository.cache.NegativeCacheHandler;
+import org.sonatype.nexus.repository.http.PartialFetchHandler;
+import org.sonatype.nexus.repository.httpclient.HttpClientFacet;
+import org.sonatype.nexus.repository.purge.PurgeUnusedFacet;
+import org.sonatype.nexus.repository.search.SearchFacet;
+import org.sonatype.nexus.repository.security.SecurityHandler;
+import org.sonatype.nexus.repository.storage.DefaultComponentMaintenanceImpl;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.UnitOfWorkHandler;
+import org.sonatype.nexus.repository.view.ConfigurableViewFacet;
+import org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler;
+import org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler;
+import org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler;
+import org.sonatype.nexus.repository.view.handlers.ExceptionHandler;
+import org.sonatype.nexus.repository.view.handlers.HandlerContributor;
+import org.sonatype.nexus.repository.view.handlers.TimingHandler;
+
+/**
+ * Support for Cargo recipes.
+ */
+public abstract class CargoRecipeSupport
+        extends RecipeSupport
+{
+    @Inject
+    protected Provider<CargoSecurityFacet> securityFacet;
+
+    @Inject
+    protected Provider<ConfigurableViewFacet> viewFacet;
+
+    @Inject
+    protected Provider<StorageFacet> storageFacet;
+
+    @Inject
+    protected Provider<SearchFacet> searchFacet;
+
+    @Inject
+    protected Provider<AttributesFacet> attributesFacet;
+
+    @Inject
+    protected Provider<DefaultComponentMaintenanceImpl> componentMaintenanceFacet;
+
+    @Inject
+    protected Provider<HttpClientFacet> httpClientFacet;
+
+    @Inject
+    protected Provider<PurgeUnusedFacet> purgeUnusedFacet;
+
+    @Inject
+    protected Provider<NegativeCacheFacet> negativeCacheFacet;
+
+    @Inject
+    protected ExceptionHandler exceptionHandler;
+
+    @Inject
+    protected TimingHandler timingHandler;
+
+    @Inject
+    protected SecurityHandler securityHandler;
+
+    @Inject
+    protected PartialFetchHandler partialFetchHandler;
+
+    @Inject
+    protected ConditionalRequestHandler conditionalRequestHandler;
+
+    @Inject
+    protected ContentHeadersHandler contentHeadersHandler;
+
+    @Inject
+    protected UnitOfWorkHandler unitOfWorkHandler;
+
+    @Inject
+    protected BrowseUnsupportedHandler browseUnsupportedHandler;
+
+    @Inject
+    protected HandlerContributor handlerContributor;
+
+    @Inject
+    protected NegativeCacheHandler negativeCacheHandler;
+
+    protected CargoRecipeSupport(final Type type, final Format format) {
+        super(type, format);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRegistryBearerToken.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRegistryBearerToken.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.security.token.BearerToken;
+
+@Named(CargoRegistryBearerToken.NAME)
+@Singleton
+public final class CargoRegistryBearerToken
+        extends BearerToken
+{
+    public static final String NAME = "CargoRegistryBearerToken";
+
+    public CargoRegistryBearerToken() {
+        super(NAME);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRegistryFacet.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRegistryFacet.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.google.gson.JsonElement;
+
+import org.sonatype.nexus.repository.Facet;
+import org.sonatype.nexus.repository.Facet.Exposed;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.Response;
+
+@Exposed
+public interface CargoRegistryFacet
+        extends Facet
+{
+    public void writeConfigJson() throws Exception;
+
+    public Response publishCrate(CrateCoordinates crateId,
+                                 JsonElement metadata,
+                                 InputStream tarball) throws IOException;
+
+    public Content downloadMetadata(CrateCoordinates crateId) throws IOException;
+
+    public Content downloadTarball(CrateCoordinates crateId) throws IOException;
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/CrateCoordinates.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/CrateCoordinates.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo;
+
+import com.vdurmont.semver4j.Semver;
+
+/* CrateCoordinates are a unique identifier for a specific crate instance.
+ * Since cargo registries have a flat namespace, only the crate name and version
+ * are required.
+ */
+public class CrateCoordinates
+{
+    protected String name;
+
+    protected Semver version;
+
+    public CrateCoordinates(String name, Semver version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public Semver getVersion() {
+        return this.version;
+    }
+
+    public String getFileBasename() {
+        return String.format("%s-%s", this.name, this.version.getValue());
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/CrateCoordinates.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/CrateCoordinates.java
@@ -41,4 +41,17 @@ public class CrateCoordinates
     public String getFileBasename() {
         return String.format("%s-%s", this.name, this.version.getValue());
     }
+
+    public String getIndexEntryPath() {
+        if (name.length() == 1) {
+            return String.format("1/%s", this.name);
+        } else if (name.length() == 2) {
+            return String.format("2/%s", this.name);
+        } else if (name.length() == 3) {
+            return String.format("3/%c/%s", this.name.charAt(0), this.name);
+        } else {
+            return String.format("%s/%s/%s", this.name.substring(0, 2), this.name.substring(2, 4),
+                    this.name);
+        }
+    }
 }

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/GitRepositoryFacet.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/GitRepositoryFacet.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo;
+
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.eclipse.jgit.lib.Repository;
+import org.sonatype.nexus.repository.Facet;
+import org.sonatype.nexus.repository.Facet.Exposed;
+
+@Exposed
+public interface GitRepositoryFacet
+        extends Facet
+{
+    @Nonnull
+    public Repository createGitRepository(String name) throws IOException;
+
+    @Nullable
+    public Repository getGitRepository(String name) throws IOException;
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/GitRepositoryFacet.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/GitRepositoryFacet.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.eclipse.jgit.lib.Repository;
+import org.sonatype.nexus.plugins.cargo.git.repo.Repository;
 import org.sonatype.nexus.repository.Facet;
 import org.sonatype.nexus.repository.Facet.Exposed;
 
@@ -31,4 +31,7 @@ public interface GitRepositoryFacet
 
     @Nullable
     public Repository getGitRepository(String name) throws IOException;
+
+    public void replaceFile(Repository repository, String branch, String entryPath, byte[] bytes)
+            throws IOException;
 }

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/Constants.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/Constants.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.sonatype.nexus.common.hash.HashAlgorithm;
+
+public class Constants
+{
+    public final static List<HashAlgorithm> OBJECT_HASHES = Arrays.asList(HashAlgorithm.SHA1);
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/GitRepositoryFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/GitRepositoryFacetImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git;
+
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.common.base.Preconditions;
+
+import org.sonatype.nexus.plugins.cargo.GitRepositoryFacet;
+import org.sonatype.nexus.plugins.cargo.git.assets.ComponentKindGitAttributes;
+import org.sonatype.nexus.plugins.cargo.git.repo.Repository;
+import org.sonatype.nexus.repository.FacetSupport;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class GitRepositoryFacetImpl
+        extends FacetSupport
+        implements GitRepositoryFacet
+{
+    private final ComponentKindGitAttributes component_attributes;
+
+    private final Repository.Builder builder;
+
+    @Inject
+    public GitRepositoryFacetImpl(ComponentKindGitAttributes component_attributes, Repository.Builder builder) {
+        this.component_attributes = component_attributes;
+        this.builder = builder;
+    }
+
+    @Override
+    @Nonnull
+    @TransactionalStoreMetadata
+    public Repository createGitRepository(String repo_name) throws IOException {
+        Preconditions.checkNotNull(repo_name, "getGitRepository called without a 'repo_name' token");
+        Component component = this.component_attributes.createGitComponent(this.getRepository(), repo_name);
+
+        StorageTx tx = UnitOfWork.currentTx();
+        Bucket bucket = tx.findBucket(this.getRepository());
+        StorageFacet storage_facet = this.getRepository().facet(StorageFacet.class);
+        Repository repo = this.builder.setStorageFacet(storage_facet).setComponent(bucket, component).build();
+
+        repo.create();
+        return repo;
+    }
+
+    @Override
+    @Nullable
+    @TransactionalTouchMetadata
+    public Repository getGitRepository(String repo_name) throws IOException {
+        Preconditions.checkNotNull(repo_name, "getGitRepository called without a 'repo_name' token");
+
+        Component component = this.component_attributes.findGitComponent(this.getRepository(), repo_name);
+        if (component == null) {
+            return null;
+        }
+
+        StorageTx tx = UnitOfWork.currentTx();
+        Bucket bucket = tx.findBucket(this.getRepository());
+        StorageFacet storage_facet = this.getRepository().facet(StorageFacet.class);
+        return this.builder.setStorageFacet(storage_facet).setComponent(bucket, component).build();
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/GitRepositoryFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/GitRepositoryFacetImpl.java
@@ -22,6 +22,21 @@ import javax.inject.Named;
 
 import com.google.common.base.Preconditions;
 
+import org.eclipse.jgit.dircache.DirCache;
+import org.eclipse.jgit.dircache.DirCacheBuilder;
+import org.eclipse.jgit.dircache.DirCacheEditor;
+import org.eclipse.jgit.dircache.DirCacheEntry;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.CommitBuilder;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.sonatype.nexus.email.EmailManager;
 import org.sonatype.nexus.plugins.cargo.GitRepositoryFacet;
 import org.sonatype.nexus.plugins.cargo.git.assets.ComponentKindGitAttributes;
 import org.sonatype.nexus.plugins.cargo.git.repo.Repository;
@@ -30,7 +45,9 @@ import org.sonatype.nexus.repository.storage.Bucket;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.StorageFacet;
 import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreBlob;
 import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
 import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
 import org.sonatype.nexus.transaction.UnitOfWork;
 
@@ -39,12 +56,18 @@ public class GitRepositoryFacetImpl
         extends FacetSupport
         implements GitRepositoryFacet
 {
+    private final EmailManager emailManager;
+
     private final ComponentKindGitAttributes component_attributes;
 
     private final Repository.Builder builder;
 
     @Inject
-    public GitRepositoryFacetImpl(ComponentKindGitAttributes component_attributes, Repository.Builder builder) {
+    public GitRepositoryFacetImpl(EmailManager emailManager,
+                                  ComponentKindGitAttributes component_attributes,
+                                  Repository.Builder builder)
+    {
+        this.emailManager = emailManager;
         this.component_attributes = component_attributes;
         this.builder = builder;
     }
@@ -80,5 +103,79 @@ public class GitRepositoryFacetImpl
         Bucket bucket = tx.findBucket(this.getRepository());
         StorageFacet storage_facet = this.getRepository().facet(StorageFacet.class);
         return this.builder.setStorageFacet(storage_facet).setComponent(bucket, component).build();
+    }
+
+    @Override
+    @TransactionalTouchMetadata
+    @TransactionalTouchBlob
+    @TransactionalStoreMetadata
+    @TransactionalStoreBlob
+    public void replaceFile(Repository repository, String branch, String entryPath, byte[] bytes) throws IOException {
+        // Calculate the ObjectId for the new contents and insert it into the object index.
+        ObjectInserter ins = repository.newObjectInserter();
+        AnyObjectId configObjId = ins.idFor(Constants.OBJ_BLOB, bytes);
+        ins.insert(Constants.OBJ_BLOB, bytes);
+        ins.flush();
+
+        // Start with a blank tree.
+        DirCache dirCache = DirCache.newInCore();
+        RevCommit parent = null;
+
+        // If there is a current HEAD, read that commit's tree. It will become
+        // our parent.
+        AnyObjectId headId = repository.resolve(branch + "^{commit}"); //$NON-NLS-1$
+        if (headId != null) {
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                parent = revWalk.parseCommit(headId);
+                DirCacheBuilder builder = dirCache.builder();
+                builder.addTree(null, DirCacheEntry.STAGE_0, repository.newObjectReader(), parent.getTree());
+                builder.finish();
+            }
+        }
+
+        // Update entryPath in the tree to point to the new ObjectId.
+        DirCacheEditor editor = dirCache.editor();
+        editor.add(new DirCacheEditor.PathEdit(entryPath)
+        {
+            @Override
+            public void apply(DirCacheEntry ent) {
+                ent.setFileMode(FileMode.REGULAR_FILE);
+                ent.setObjectId(configObjId);
+            }
+        });
+        editor.finish();
+        AnyObjectId indexTreeId = dirCache.writeTree(ins);
+
+        // Check for empty commits
+        if (parent != null && indexTreeId.equals(parent.getTree())) {
+            return;
+        }
+
+        // Create a Commit object, populate it and write it
+        PersonIdent adminIdent = new PersonIdent("Nexus System", this.emailManager.getConfiguration().getFromAddress());
+        CommitBuilder commit = new CommitBuilder();
+        commit.setCommitter(adminIdent);
+        commit.setAuthor(adminIdent);
+        commit.setMessage("Update " + entryPath);
+        if (parent != null) {
+            commit.setParentIds(parent);
+        }
+        commit.setTreeId(indexTreeId);
+        AnyObjectId commitId = ins.insert(commit);
+        ins.flush();
+
+        try (RevWalk revWalk = new RevWalk(repository)) {
+            RevCommit revCommit = revWalk.parseCommit(commitId);
+            RefUpdate headUpdate = repository.updateRef(branch);
+            headUpdate.setNewObjectId(commitId);
+            String reflogMsgPrefix = parent == null ? "commit (initial): " : "commit: ";
+            headUpdate.setRefLogMessage(reflogMsgPrefix + revCommit.getShortMessage(), false);
+
+            if (headId != null)
+                headUpdate.setExpectedOldObjectId(headId);
+            else
+                headUpdate.setExpectedOldObjectId(ObjectId.zeroId());
+            headUpdate.forceUpdate();
+        }
     }
 }

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/GitRepositoryHandlers.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/GitRepositoryHandlers.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.http.HttpHeaders;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.PacketLineOut;
+import org.eclipse.jgit.transport.ReceivePack;
+import org.eclipse.jgit.transport.RefAdvertiser;
+import org.eclipse.jgit.transport.UploadPack;
+import org.sonatype.goodies.common.ComponentSupport;
+import org.sonatype.nexus.plugins.cargo.GitRepositoryFacet;
+import org.sonatype.nexus.repository.http.HttpMethods;
+import org.sonatype.nexus.repository.http.HttpResponses;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Handler;
+import org.sonatype.nexus.repository.view.Payload;
+import org.sonatype.nexus.repository.view.Response;
+import org.sonatype.nexus.repository.view.matchers.ActionMatcher;
+import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
+import org.sonatype.nexus.repository.view.payloads.BytesPayload;
+import org.sonatype.nexus.security.SecuritySystem;
+import org.sonatype.nexus.security.user.User;
+
+public class GitRepositoryHandlers
+{
+    /** Name of the git-upload-pack service. */
+    public static final String UPLOAD_PACK = "git-upload-pack";
+
+    /** Content type supplied by the client to the /info/refs?service=git-upload-pack handler. */
+    public static final String UPLOAD_PACK_ADVERTISEMENT_TYPE = "application/x-git-upload-pack-advertisement";
+
+    /** Content type supplied by the client to the /git-upload-pack handler. */
+    public static final String UPLOAD_PACK_REQUEST_TYPE = "application/x-git-upload-pack-request";
+
+    /** Content type returned from the /git-upload-pack handler. */
+    public static final String UPLOAD_PACK_RESULT_TYPE = "application/x-git-upload-pack-result";
+
+    /** Name of the git-receive-pack service. */
+    public static final String RECEIVE_PACK = "git-receive-pack";
+
+    /** Content type supplied by the client to the /info/refs?service=git-receive-pack handler. */
+    public static final String RECEIVE_PACK_ADVERTISEMENT_TYPE = "application/x-git-receive-pack-advertisement";
+
+    /** Content type supplied by the client to the /git-receive-pack handler. */
+    public static final String RECEIVE_PACK_REQUEST_TYPE = "application/x-git-receive-pack-request";
+
+    /** Content type returned from the /git-receive-pack handler. */
+    public static final String RECEIVE_PACK_RESULT_TYPE = "application/x-git-receive-pack-result";
+
+    private final static String[] GET_REQUEST_METHODS = {HttpMethods.GET, HttpMethods.HEAD};
+
+    private final static String[] PUT_REQUEST_METHODS = {HttpMethods.POST};
+
+    private static abstract class GitHandlerSupport
+            extends ComponentSupport
+            implements Handler
+    {
+        protected Repository getGitRepository(Context context) throws IOException {
+            TokenMatcher.State state = context.getAttributes().require(TokenMatcher.State.class);
+            String repo_name = state.getTokens().get("repo_name");
+
+            GitRepositoryFacet facet = context.getRepository().facet(GitRepositoryFacet.class);
+            return facet.getGitRepository(repo_name);
+        }
+
+        protected static Response setUncachedResponse(Response response) {
+            return new Response.Builder().copy(response).header(HttpHeaders.EXPIRES, "Fri, 01 Jan 1980 00:00:00 GMT")
+                    .header(HttpHeaders.PRAGMA, "no-cache")
+                    .header(HttpHeaders.CACHE_CONTROL, "no-cache, max-age=0, must-revalidate").build();
+        }
+
+        protected static Response buildBadRequestResponse(String[] allowed_methods) {
+            return setUncachedResponse(new Response.Builder().copy(HttpResponses.badRequest())
+                    .header(HttpHeaders.ALLOW, String.join(", ", allowed_methods)).build());
+        };
+    }
+
+    @Named
+    public static class Default
+            extends GitHandlerSupport
+    {
+        @Override
+        public Response handle(Context context) throws Exception {
+            return HttpResponses.notFound();
+        }
+    };
+
+    @Named
+    public static class InfoRefs
+            extends GitHandlerSupport
+    {
+        @Override
+        public Response handle(Context context) throws Exception {
+            if (!new ActionMatcher(GET_REQUEST_METHODS).matches(context)) {
+                return buildBadRequestResponse(GET_REQUEST_METHODS);
+            }
+
+            String requested_service = context.getRequest().getParameters().get("service");
+            if (requested_service == null) {
+                return HttpResponses.forbidden("git over dump-http is not supported");
+            }
+            else if (requested_service.equalsIgnoreCase(UPLOAD_PACK)) {
+                return handleSmartUploadPackService(context);
+            }
+            else if (requested_service.equalsIgnoreCase(RECEIVE_PACK)) {
+                return handleSmartReceivePackService(context);
+            }
+            else {
+                return HttpResponses.forbidden("unknown service");
+            }
+        }
+
+        @TransactionalTouchMetadata
+        public Response handleSmartUploadPackService(Context context) throws Exception {
+            ByteArrayOutputStream out_bytes = new ByteArrayOutputStream();
+            final PacketLineOut packet_line_out = new PacketLineOut(out_bytes);
+
+            packet_line_out.writeString("# service=" + UPLOAD_PACK + "\n");
+            packet_line_out.end();
+
+            Repository gitRepo = getGitRepository(context);
+            if (gitRepo == null)
+                return HttpResponses.notFound("unknown repository");
+
+            UploadPack service = new UploadPack(gitRepo);
+            service.setBiDirectionalPipe(false);
+            service.sendAdvertisedRefs(new RefAdvertiser.PacketLineOutRefAdvertiser(packet_line_out));
+
+            Payload payload = new BytesPayload(out_bytes.toByteArray(), UPLOAD_PACK_ADVERTISEMENT_TYPE);
+            return HttpResponses.ok(payload);
+        }
+
+        @TransactionalTouchMetadata
+        public Response handleSmartReceivePackService(Context context) throws Exception {
+            ByteArrayOutputStream out_bytes = new ByteArrayOutputStream();
+            final PacketLineOut packet_line_out = new PacketLineOut(out_bytes);
+
+            packet_line_out.writeString("# service=" + RECEIVE_PACK + "\n");
+            packet_line_out.end();
+
+            Repository gitRepo = getGitRepository(context);
+            if (gitRepo == null)
+                return HttpResponses.notFound("unknown repository");
+
+            ReceivePack service = new ReceivePack(gitRepo);
+            service.setBiDirectionalPipe(false);
+            service.sendAdvertisedRefs(new RefAdvertiser.PacketLineOutRefAdvertiser(packet_line_out));
+
+            Payload payload = new BytesPayload(out_bytes.toByteArray(), RECEIVE_PACK_ADVERTISEMENT_TYPE);
+            return HttpResponses.ok(payload);
+        }
+
+    };
+
+    @Named
+    public static class UploadPackService
+            extends GitHandlerSupport
+    {
+        @Override
+        @TransactionalTouchMetadata
+        @TransactionalTouchBlob
+        public Response handle(Context context) throws Exception {
+            if (!new ActionMatcher(PUT_REQUEST_METHODS).matches(context)) {
+                this.createLogger().debug("Wrong upload-pack action: {}", context.getRequest());
+                return buildBadRequestResponse(PUT_REQUEST_METHODS);
+            }
+
+            if (!context.getRequest().getPayload().getContentType().equals(UPLOAD_PACK_REQUEST_TYPE)) {
+                this.createLogger().debug("Wrong upload-pack content type: {}",
+                        context.getRequest().getPayload().getContentType());
+                return HttpResponses.badRequest();
+            }
+
+            Repository gitRepo = getGitRepository(context);
+            if (gitRepo == null)
+                return HttpResponses.notFound("unknown repository");
+
+            UploadPack service = new UploadPack(gitRepo);
+            service.setBiDirectionalPipe(false);
+
+            ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+            service.upload(context.getRequest().getPayload().openInputStream(), outputBytes, null);
+
+            Payload payload = new BytesPayload(outputBytes.toByteArray(), UPLOAD_PACK_RESULT_TYPE);
+            return HttpResponses.ok(payload);
+        }
+    };
+
+    @Named
+    public static class ReceivePackService
+            extends GitHandlerSupport
+    {
+        private final SecuritySystem securitySytem;
+
+        @Inject
+        public ReceivePackService(SecuritySystem securitySystem) {
+            this.securitySytem = securitySystem;
+        }
+
+        @Override
+        @TransactionalStoreBlob
+        @TransactionalStoreMetadata
+        public Response handle(Context context) throws Exception {
+            if (!new ActionMatcher(PUT_REQUEST_METHODS).matches(context)) {
+                this.createLogger().debug("Wrong receive-pack action: {}", context.getRequest());
+                return buildBadRequestResponse(PUT_REQUEST_METHODS);
+            }
+
+            if (!context.getRequest().getPayload().getContentType().equals(RECEIVE_PACK_REQUEST_TYPE)) {
+                this.createLogger().debug("Wrong receive-pack content type: {}",
+                        context.getRequest().getPayload().getContentType());
+                return HttpResponses.badRequest();
+            }
+
+            Repository gitRepo = getGitRepository(context);
+            if (gitRepo == null)
+                return HttpResponses.notFound("unknown repository");
+
+            ReceivePack service = new ReceivePack(gitRepo);
+            service.setBiDirectionalPipe(false);
+            service.setEchoCommandFailures(true);
+
+            // Figure out the user who is making this request so reflog identification can be
+            // set.
+            User user = this.securitySytem.currentUser();
+            PersonIdent userPerson = new PersonIdent(user.getName(), user.getEmailAddress());
+            service.setRefLogIdent(userPerson);
+
+            ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+            service.receive(context.getRequest().getPayload().openInputStream(), outputBytes, null);
+            Payload payload = new BytesPayload(outputBytes.toByteArray(), RECEIVE_PACK_RESULT_TYPE);
+            return HttpResponses.ok(payload);
+        }
+    };
+
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKind.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKind.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.assets;
+
+import javax.annotation.Nonnull;
+
+import org.sonatype.nexus.repository.cache.CacheControllerHolder;
+import org.sonatype.nexus.repository.cache.CacheControllerHolder.CacheType;
+
+public enum AssetKind
+{
+    OBJECT(CacheControllerHolder.CONTENT), CONFIG(CacheControllerHolder.METADATA), REF(CacheControllerHolder.METADATA);
+
+    private final CacheType cache_type;
+
+    AssetKind(final CacheType cacheType) {
+        this.cache_type = cacheType;
+    }
+
+    @Nonnull
+    public CacheType getCacheType() {
+        return cache_type;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindConfigAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindConfigAttributes.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.assets;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.inject.Named;
+
+import org.sonatype.nexus.blobstore.api.Blob;
+import org.sonatype.nexus.plugins.cargo.git.Constants;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetEntityAdapter;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.repository.view.ContentTypes;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class AssetKindConfigAttributes
+{
+    private static String getAttributePropertyName(String format_attribute) {
+        return MetadataNodeEntityAdapter.P_ATTRIBUTES + "." + format_attribute;
+    }
+
+    @TransactionalStoreMetadata
+    public Asset createConfigAsset(Bucket bucket, Component component) {
+        StorageTx tx = UnitOfWork.currentTx();
+        Asset configAsset = tx.createAsset(bucket, component);
+        configAsset.attributes().set(AssetEntityAdapter.P_ASSET_KIND, AssetKind.CONFIG.name());
+        tx.saveAsset(configAsset);
+        return configAsset;
+    }
+
+    @TransactionalTouchMetadata
+    public Asset findConfigAsset(Bucket bucket, Component component) {
+        // Find the repository's stored config asset. If there isn't one, create
+        // one.
+        StorageTx tx = UnitOfWork.currentTx();
+        return tx.findAssetWithProperty(getAttributePropertyName(AssetEntityAdapter.P_ASSET_KIND),
+                AssetKind.CONFIG.name(), component);
+    }
+
+    @TransactionalTouchBlob
+    public InputStream getContents(Asset config_asset) {
+        StorageTx tx = UnitOfWork.currentTx();
+        Blob contents = tx.getBlob(config_asset.blobRef());
+        return contents.getInputStream();
+    }
+
+    @TransactionalStoreBlob
+    public void setContents(Asset config_asset, InputStream stream) throws IOException {
+        // Attach config in text format to the above Asset as a blob.
+        StorageTx tx = UnitOfWork.currentTx();
+        tx.setBlob(config_asset, "config", () -> stream, Constants.OBJECT_HASHES, null, ContentTypes.TEXT_PLAIN, true);
+        tx.saveAsset(config_asset);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindObjectAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindObjectAttributes.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.assets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.inject.Named;
+
+import com.google.common.base.Suppliers;
+import com.google.inject.Inject;
+
+import org.eclipse.jgit.lib.AbbreviatedObjectId;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.ObjectId;
+import org.sonatype.goodies.common.Loggers;
+import org.sonatype.nexus.blobstore.api.Blob;
+import org.sonatype.nexus.common.hash.HashAlgorithm;
+import org.sonatype.nexus.plugins.cargo.git.Constants;
+import org.sonatype.nexus.plugins.cargo.git.repo.ObjectIdHashFunction;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetBlob;
+import org.sonatype.nexus.repository.storage.AssetEntityAdapter;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.BucketEntityAdapter;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.ComponentEntityAdapter;
+import org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter;
+import org.sonatype.nexus.repository.storage.Query;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class AssetKindObjectAttributes
+{
+    private final static String P_OBJECT_TYPE = "git-object-type";
+
+    private final static String CONTENT_TYPE_LOOSE_OBJECT = "application/x-git-loose-object";
+
+    protected BucketEntityAdapter bucketEntityAdapter;
+
+    protected ComponentEntityAdapter componentEntityAdapter;
+
+    private static String getAttributePropertyName(String format_attribute) {
+        return MetadataNodeEntityAdapter.P_ATTRIBUTES + "." + format_attribute;
+    }
+
+    @Inject
+    protected AssetKindObjectAttributes(BucketEntityAdapter bucketEntityAdapter,
+                                        ComponentEntityAdapter componentEntityAdapter)
+    {
+        this.bucketEntityAdapter = bucketEntityAdapter;
+        this.componentEntityAdapter = componentEntityAdapter;
+    }
+
+    @TransactionalTouchMetadata
+    @TransactionalTouchBlob
+    public Asset createObjectAsset(Bucket bucket,
+                                   Component component,
+                                   int object_type,
+                                   long length,
+                                   InputStream contents) throws IOException
+    {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        // Calculate the Git object id while the blob is being written.
+        HashAlgorithm object_id_hash =
+                new HashAlgorithm("git-object-id", new ObjectIdHashFunction(object_type, length));
+        List<HashAlgorithm> hashes = new ArrayList<HashAlgorithm>(Constants.OBJECT_HASHES);
+        hashes.add(object_id_hash);
+
+        // Create a blob from the contents of the InputStream. This will be a
+        // unique blob but the object ID may already exist. The blob will be
+        // thrown away if it isn't attached to an Asset.
+        AssetBlob assetBlob = tx.createBlob("git-object", Suppliers.ofInstance(contents), hashes, null,
+                CONTENT_TYPE_LOOSE_OBJECT, true);
+
+        // If the calculated ObjectId is already saved in the object database,
+        // we're done.
+        ObjectId object_id = ObjectId.fromRaw(assetBlob.getHashes().get(object_id_hash).asBytes());
+        Asset existing_asset = this.findObjectAssetWithObjectId(bucket, component, object_id);
+        if (existing_asset != null)
+            return existing_asset;
+
+        // Create an Asset to hold the new Git object. Attach the objectType as metadata.
+        Asset asset = tx.createAsset(bucket, component);
+        asset.name(object_id.name());
+        asset.attributes().set(AssetEntityAdapter.P_ASSET_KIND, AssetKind.OBJECT.name());
+        setObjectType(asset, object_type);
+        tx.attachBlob(asset, assetBlob);
+        tx.saveAsset(asset);
+
+        Loggers.getLogger(this).debug("Inserting object asset (type={}, length={}): {}", object_type, length, asset);
+        Loggers.getLogger(this).debug("Inserted blob (id={}, headers={}, metrics={})", assetBlob.getBlob().getId(),
+                assetBlob.getBlob().getHeaders(), assetBlob.getBlob().getMetrics().toString());
+        return asset;
+    }
+
+    @TransactionalTouchMetadata
+    public Iterable<Asset> browseObjectAssetByAbbreviatedObjectId(Bucket bucket,
+                                                                  Component component,
+                                                                  AbbreviatedObjectId object_id)
+    {
+        StorageTx tx = UnitOfWork.currentTx();
+        Query ids_like_abbrev = Query.builder().where(AssetEntityAdapter.P_BUCKET)
+                .eq(bucketEntityAdapter.recordIdentity(bucket)).and(AssetEntityAdapter.P_COMPONENT)
+                .eq(componentEntityAdapter.recordIdentity(component))
+                .and(getAttributePropertyName(AssetEntityAdapter.P_ASSET_KIND))
+                .and(AssetEntityAdapter.P_NAME + " like ").param(object_id.name() + "%").and("LIMIT 256").build();
+        Loggers.getLogger(this).debug("Looking for objects matching \"{}\"\nQuery: {}", object_id.name(),
+                ids_like_abbrev.toString());
+        return tx.findAssets(ids_like_abbrev, null);
+    }
+
+    @TransactionalTouchMetadata
+    public Asset findObjectAssetWithObjectId(Bucket bucket, Component component, AnyObjectId object_id) {
+        Loggers.getLogger(this).debug("Looking for objects matching \"{}\"", object_id.name());
+
+        StorageTx tx = UnitOfWork.currentTx();
+        Iterator<Asset> objAssets = tx.findAssets(
+                Query.builder().where(AssetEntityAdapter.P_BUCKET).eq(bucketEntityAdapter.recordIdentity(bucket))
+                        .and(AssetEntityAdapter.P_COMPONENT).eq(componentEntityAdapter.recordIdentity(component))
+                        .and(getAttributePropertyName(AssetEntityAdapter.P_ASSET_KIND)).eq(AssetKind.OBJECT.name())
+                        .and(AssetEntityAdapter.P_NAME).eq(object_id.name()).build(),
+                null).iterator();
+        return objAssets.hasNext() ? objAssets.next() : null;
+    }
+
+    public ObjectId getObjectId(Asset obj_asset) {
+        return ObjectId.fromString(obj_asset.name());
+    }
+
+    public int getObjectType(Asset obj_asset) {
+        return obj_asset.formatAttributes().require(P_OBJECT_TYPE, Integer.class);
+    }
+
+    public void setObjectType(Asset obj_asset, int object_type) {
+        obj_asset.formatAttributes().set(P_OBJECT_TYPE, new Integer(object_type));
+    }
+
+    @TransactionalTouchBlob
+    public InputStream getContents(Asset obj_asset) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+        Blob blob = tx.getBlob(obj_asset.requireBlobRef());
+        if (blob == null) {
+            return null;
+        }
+
+        return blob.getInputStream();
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindRefAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindRefAttributes.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.assets;
+
+import java.util.Iterator;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectIdRef;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.SymbolicRef;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetEntityAdapter;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.BucketEntityAdapter;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.ComponentEntityAdapter;
+import org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter;
+import org.sonatype.nexus.repository.storage.Query;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class AssetKindRefAttributes
+{
+    public final static String P_REF_TYPE = "git-ref-type";
+
+    public final static String I_REF_TYPE_OBJECT_ID_UNPEELED = "object-id-unpeeled";
+
+    public final static String I_REF_TYPE_OBJECT_ID_PEELED_TAG = "object-id-peeled-tag";
+
+    public final static String I_REF_TYPE_OBJECT_ID_PEELED_NONTAG = "object-id-peeled-nontag";
+
+    public final static String I_REF_TYPE_SYMBOLIC = "symbolic";
+
+    public final static String P_REF_TARGET = "git-ref-target";
+
+    public final static String P_REF_PEELED_OBJECT_ID = "git-ref-peeled-object-id";
+
+    protected BucketEntityAdapter bucketEntityAdapter;
+
+    protected ComponentEntityAdapter componentEntityAdapter;
+
+    private static String getAttributePropertyName(String format_attribute) {
+        return MetadataNodeEntityAdapter.P_ATTRIBUTES + "." + format_attribute;
+    }
+
+    @Inject
+    protected AssetKindRefAttributes(BucketEntityAdapter bucketEntityAdapter,
+                                     ComponentEntityAdapter componentEntityAdapter)
+    {
+        this.bucketEntityAdapter = bucketEntityAdapter;
+        this.componentEntityAdapter = componentEntityAdapter;
+    }
+
+    @TransactionalStoreMetadata
+    public Asset createRefAsset(Bucket bucket, Component component, String name) {
+        StorageTx tx = UnitOfWork.currentTx();
+        Asset asset = tx.createAsset(bucket, component);
+        asset.name(name);
+        asset.attributes().set(AssetEntityAdapter.P_ASSET_KIND, AssetKind.REF.name());
+
+        return asset;
+    }
+
+    @TransactionalTouchMetadata
+    public Iterable<Asset> browseRefAssetsByPrefix(Bucket bucket, Component component, String prefix) {
+        StorageTx tx = UnitOfWork.currentTx();
+        Query.Builder query_builder =
+                Query.builder().where(AssetEntityAdapter.P_BUCKET).eq(bucketEntityAdapter.recordIdentity(bucket))
+                        .and(AssetEntityAdapter.P_COMPONENT).eq(componentEntityAdapter.recordIdentity(component))
+                        .and(getAttributePropertyName(AssetEntityAdapter.P_ASSET_KIND)).eq(AssetKind.REF.name());
+
+        if (!prefix.isEmpty()) {
+            query_builder = query_builder.and(AssetEntityAdapter.P_NAME).where(" LIKE ").param(prefix + "%");
+        }
+
+        return tx.findAssets(query_builder.build(), null);
+    }
+
+    @TransactionalTouchMetadata
+    public Asset findRefAssetWithName(Bucket bucket, Component component, String name) {
+        StorageTx tx = UnitOfWork.currentTx();
+        Iterator<Asset> refAssets = tx.findAssets(
+                Query.builder().where(AssetEntityAdapter.P_BUCKET).eq(bucketEntityAdapter.recordIdentity(bucket))
+                        .and(AssetEntityAdapter.P_COMPONENT).eq(componentEntityAdapter.recordIdentity(component))
+                        .and(getAttributePropertyName(AssetEntityAdapter.P_ASSET_KIND)).eq(AssetKind.REF.name())
+                        .and(AssetEntityAdapter.P_NAME).eq(name).build(),
+                null).iterator();
+        return refAssets.hasNext() ? refAssets.next() : null;
+    }
+
+    public Ref getRef(Bucket bucket, Component component, Asset asset) {
+        switch (asset.formatAttributes().require(P_REF_TYPE, String.class)) {
+            case I_REF_TYPE_OBJECT_ID_UNPEELED:
+                return new ObjectIdRef.Unpeeled(Ref.Storage.LOOSE, asset.name(), ObjectId.fromString(getTarget(asset)));
+            case I_REF_TYPE_OBJECT_ID_PEELED_TAG:
+                return new ObjectIdRef.PeeledTag(Ref.Storage.LOOSE, asset.name(), ObjectId.fromString(getTarget(asset)),
+                        getPeeledObjectId(asset));
+            case I_REF_TYPE_OBJECT_ID_PEELED_NONTAG:
+                return new ObjectIdRef.PeeledNonTag(Ref.Storage.LOOSE, asset.name(),
+                        ObjectId.fromString(getTarget(asset)));
+            case I_REF_TYPE_SYMBOLIC:
+                Asset targetAsset = findRefAssetWithName(bucket, component, getTarget(asset));
+                if (targetAsset == null)
+                    return null;
+
+                return new SymbolicRef(asset.name(), getRef(bucket, component, targetAsset));
+        }
+
+        return null;
+    }
+
+    @TransactionalStoreMetadata
+    public void setRef(Asset asset, Ref ref) {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        if (ref.isSymbolic()) {
+            asset.formatAttributes().set(P_REF_TYPE, I_REF_TYPE_SYMBOLIC);
+            asset.formatAttributes().set(P_REF_TARGET, ref.getTarget().getName());
+        }
+        else {
+            asset.formatAttributes().set(P_REF_TARGET, ref.getObjectId().getName());
+
+            if (!ref.isPeeled()) {
+                asset.formatAttributes().set(P_REF_TYPE, I_REF_TYPE_OBJECT_ID_UNPEELED);
+            }
+            else {
+                ObjectId peeledObjectId = ref.getPeeledObjectId();
+                if (peeledObjectId != null) {
+                    asset.formatAttributes().set(P_REF_TYPE, I_REF_TYPE_OBJECT_ID_PEELED_TAG);
+                    asset.formatAttributes().set(P_REF_PEELED_OBJECT_ID, peeledObjectId.getName());
+                }
+                else {
+                    asset.formatAttributes().set(P_REF_TYPE, I_REF_TYPE_OBJECT_ID_PEELED_NONTAG);
+                }
+            }
+        }
+
+        tx.saveAsset(asset);
+    }
+
+    private String getTarget(Asset asset) {
+        return asset.formatAttributes().require(P_REF_TARGET, String.class);
+    }
+
+    private ObjectId getPeeledObjectId(Asset asset) {
+        String obj_id = asset.formatAttributes().require(P_REF_PEELED_OBJECT_ID, String.class);
+        return ObjectId.fromString(obj_id);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/ComponentKindGitAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/ComponentKindGitAttributes.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.assets;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import javax.inject.Named;
+
+import com.google.common.collect.Iterables;
+
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.ComponentEntityAdapter;
+import org.sonatype.nexus.repository.storage.Query;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class ComponentKindGitAttributes
+{
+    final private String I_GROUP_GIT = "git";
+
+    @TransactionalStoreMetadata
+    public Component createGitComponent(Repository repository, String repo_name) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+        Bucket bucket = tx.findBucket(repository);
+
+        // This could be the first time the bucket is referenced which means it
+        // doesn't actually exist in the database. Go ahead and save it to
+        // force the record to be populated.
+        tx.saveBucket(bucket);
+
+        Component component = tx.createComponent(bucket, repository.getFormat());
+        component.name(repo_name);
+        component.group(I_GROUP_GIT);
+        tx.saveComponent(component);
+
+        return component;
+    }
+
+    @TransactionalTouchMetadata
+    public Component findGitComponent(Repository repository, String repo_name) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        Iterable<Component> components =
+                tx.findComponents(
+                        Query.builder().where(ComponentEntityAdapter.P_GROUP).eq(I_GROUP_GIT)
+                                .and(ComponentEntityAdapter.P_NAME).eq(repo_name).build(),
+                        Collections.singletonList(repository));
+
+        return Iterables.getOnlyElement(components, null);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/AttributesNodeProvider.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/AttributesNodeProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.attributes.AttributesNode;
+
+public class AttributesNodeProvider
+        implements org.eclipse.jgit.attributes.AttributesNodeProvider
+{
+    private final AttributesNode global_node;
+
+    private final AttributesNode info_node;
+
+    AttributesNodeProvider() {
+        this.global_node = new AttributesNode();
+        this.info_node = new AttributesNode();
+    }
+
+    @Override
+    public AttributesNode getGlobalAttributesNode() throws IOException {
+        return this.global_node;
+    }
+
+    @Override
+    public AttributesNode getInfoAttributesNode() throws IOException {
+        return this.info_node;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectDatabase.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectDatabase.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+public class ObjectDatabase
+        extends org.eclipse.jgit.lib.ObjectDatabase
+{
+    private final Repository db;
+
+    ObjectDatabase(Repository db) {
+        this.db = db;
+    }
+
+    @Override
+    public ObjectReader newReader() {
+        return new ObjectReader(db);
+    }
+
+    @Override
+    public ObjectInserter newInserter() {
+        return new ObjectInserter(db);
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectIdHashFunction.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectIdHashFunction.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import com.google.common.hash.Funnel;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+
+import org.eclipse.jgit.lib.Constants;
+
+public class ObjectIdHashFunction
+        implements HashFunction
+{
+    private final int object_type;
+
+    private final long object_size;
+
+    public ObjectIdHashFunction(int object_type, long object_size) {
+        this.object_type = object_type;
+        this.object_size = object_size;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public int bits() {
+        return Hashing.sha1().bits();
+    }
+
+    @Override
+    public HashCode hashBytes(ByteBuffer input) {
+        return newHasher().putBytes(input).hash();
+    }
+
+    @Override
+    public HashCode hashBytes(byte[] input) {
+        return newHasher().putBytes(input).hash();
+    }
+
+    @Override
+    public HashCode hashBytes(byte[] input, int off, int len) {
+        return newHasher().putBytes(input, off, len).hash();
+    }
+
+    @Override
+    public HashCode hashInt(int input) {
+        return newHasher().putInt(input).hash();
+    }
+
+    @Override
+    public HashCode hashLong(long input) {
+        return newHasher().putLong(input).hash();
+    }
+
+    @Override
+    public <T> HashCode hashObject(T instance, Funnel<? super T> funnel) {
+        return newHasher().putObject(instance, funnel).hash();
+    }
+
+    @Override
+    public HashCode hashString(CharSequence input, Charset charset) {
+        return newHasher().putString(input, charset).hash();
+    }
+
+    @Override
+    public HashCode hashUnencodedChars(CharSequence input) {
+        return newHasher().putUnencodedChars(input).hash();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public Hasher newHasher() {
+        return putHeader(Hashing.sha1().newHasher());
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public Hasher newHasher(int expectedInputSize) {
+        return putHeader(Hashing.sha1().newHasher(expectedInputSize));
+    }
+
+    private Hasher putHeader(Hasher hash) {
+        return hash.putBytes(Constants.encodedTypeString(this.object_type)).putByte((byte) ' ')
+                .putBytes(Constants.encodeASCII(this.object_size)).putByte((byte) 0);
+    }
+
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectInserter.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectInserter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.sonatype.nexus.plugins.cargo.git.Constants;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindObjectAttributes;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.TempBlob;
+
+public class ObjectInserter
+        extends org.eclipse.jgit.lib.ObjectInserter
+{
+    private final Repository db;
+
+    private final AssetKindObjectAttributes asset_attributes;
+
+    private final StorageFacet storage_facet;
+
+    private final Bucket bucket;
+
+    private final Component component;
+
+    ObjectInserter(Repository db) {
+        this.db = db;
+        this.asset_attributes = db.getAssetAttributesObject();
+        this.storage_facet = db.getStorageFacet();
+        this.bucket = db.getBucket();
+        this.component = db.getComponent();
+    }
+
+    @Override
+    public ObjectId insert(int object_type, long length, InputStream in) throws IOException {
+        Asset asset = asset_attributes.createObjectAsset(this.bucket, this.component, object_type, length, in);
+        return asset_attributes.getObjectId(asset);
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do as insert() queues all the work in the current transaction.
+    }
+
+    @Override
+    public void flush() throws IOException {
+        // Nothing to do as insert() queues all the work in the current transaction.
+    }
+
+    @Override
+    public PackParser newPackParser(InputStream in) throws IOException {
+        TempBlob packBlob = storage_facet.createTempBlob(in, Constants.OBJECT_HASHES);
+        return new PackParser(this.db, packBlob);
+    }
+
+    @Override
+    public ObjectReader newReader() {
+        return new ObjectReader(this.db);
+    }
+
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectInserter.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectInserter.java
@@ -16,14 +16,15 @@ package org.sonatype.nexus.plugins.cargo.git.repo;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.eclipse.jgit.lib.ObjectId;
 import org.sonatype.nexus.plugins.cargo.git.Constants;
 import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindObjectAttributes;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Bucket;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.StorageFacet;
-import org.sonatype.nexus.repository.storage.TempBlob;
+import org.sonatype.nexus.repository.view.payloads.TempBlob;
+
+import org.eclipse.jgit.lib.ObjectId;
 
 public class ObjectInserter
         extends org.eclipse.jgit.lib.ObjectInserter

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectLoader.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectLoader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.jgit.errors.LargeObjectException;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.ObjectStream;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindObjectAttributes;
+import org.sonatype.nexus.repository.storage.Asset;
+
+public class ObjectLoader
+        extends org.eclipse.jgit.lib.ObjectLoader
+{
+    private final AssetKindObjectAttributes asset_attributes;
+
+    private final AnyObjectId obj_id;
+
+    private final Asset obj_asset;
+
+    ObjectLoader(Repository db, AnyObjectId obj_id, Asset obj_asset) {
+        super();
+        this.asset_attributes = db.getAssetAttributesObject();
+        this.obj_id = obj_id;
+        this.obj_asset = obj_asset;
+    }
+
+    @Override
+    public int getType() {
+        return asset_attributes.getObjectType(obj_asset);
+    }
+
+    @Override
+    public long getSize() {
+        return obj_asset.size();
+    }
+
+    @Override
+    public boolean isLarge() {
+        return true;
+    }
+
+    @Override
+    public byte[] getCachedBytes() throws LargeObjectException {
+        throw new LargeObjectException(this.obj_id);
+    }
+
+    @Override
+    public ObjectStream openStream() throws MissingObjectException, IOException {
+        InputStream contents = asset_attributes.getContents(this.obj_asset);
+        if (contents == null) {
+            throw new MissingObjectException(this.obj_id.toObjectId(), this.getType());
+        }
+
+        return new ObjectStream.Filter(this.getType(), this.getSize(), contents);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectReader.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/ObjectReader.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.internal.JGitText;
+import org.eclipse.jgit.lib.AbbreviatedObjectId;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
+import org.eclipse.jgit.storage.pack.PackConfig;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindObjectAttributes;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+
+public class ObjectReader
+        extends org.eclipse.jgit.lib.ObjectReader
+{
+    private final Repository db;
+
+    private final AssetKindObjectAttributes asset_attributes;
+
+    private final PackConfig pack_config;
+
+    private final Bucket bucket;
+
+    private final Component component;
+
+    ObjectReader(Repository db) {
+        super();
+        this.db = db;
+        this.asset_attributes = db.getAssetAttributesObject();
+        this.pack_config = new PackConfig(db);
+        this.bucket = db.getBucket();
+        this.component = db.getComponent();
+    }
+
+    @Override
+    public boolean has(AnyObjectId object_id, int type_hint) throws IOException {
+        Asset obj_asset = asset_attributes.findObjectAssetWithObjectId(bucket, component, object_id);
+        if (obj_asset == null)
+            return false;
+
+        if (type_hint != OBJ_ANY && type_hint != asset_attributes.getObjectType(obj_asset)) {
+            throw new IncorrectObjectTypeException(object_id.toObjectId(), type_hint);
+        }
+
+        return true;
+    }
+
+    @Override
+    public ObjectLoader open(AnyObjectId object_id,
+                             int type_hint) throws MissingObjectException, IncorrectObjectTypeException, IOException
+    {
+        Asset obj_asset = asset_attributes.findObjectAssetWithObjectId(bucket, component, object_id);
+        if (obj_asset == null) {
+            if (type_hint == OBJ_ANY)
+                throw new MissingObjectException(object_id.copy(), JGitText.get().unknownObjectType2);
+
+            throw new MissingObjectException(object_id.toObjectId(), type_hint);
+        }
+        if (type_hint != OBJ_ANY && type_hint != asset_attributes.getObjectType(obj_asset)) {
+            throw new IncorrectObjectTypeException(object_id.toObjectId(), type_hint);
+        }
+
+        if (obj_asset.size() < this.pack_config.getBigFileThreshold()) {
+            ByteArrayOutputStream obj_buf = new ByteArrayOutputStream(obj_asset.size().intValue());
+            IOUtils.copy(this.asset_attributes.getContents(obj_asset), obj_buf);
+            return new ObjectLoader.SmallObject(this.asset_attributes.getObjectType(obj_asset), obj_buf.toByteArray());
+        }
+        else {
+            return new org.sonatype.nexus.plugins.cargo.git.repo.ObjectLoader(this.db, object_id, obj_asset);
+        }
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public Collection<ObjectId> resolve(AbbreviatedObjectId id) throws IOException {
+        List<ObjectId> matching_ids = new ArrayList<ObjectId>();
+        for (Asset obj_asset : asset_attributes.browseObjectAssetByAbbreviatedObjectId(bucket, component, id)) {
+            matching_ids.add(asset_attributes.getObjectId(obj_asset));
+        }
+
+        return matching_ids;
+    }
+
+    @Override
+    public org.eclipse.jgit.lib.ObjectReader newReader() {
+        return new ObjectReader(db);
+    }
+
+    @Override
+    public Set<ObjectId> getShallowCommits() throws IOException {
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/PackParser.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/PackParser.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.zip.CRC32;
+import java.util.zip.InflaterInputStream;
+
+import org.eclipse.jgit.internal.storage.file.PackLock;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.ProgressMonitor;
+import org.eclipse.jgit.transport.PackedObjectInfo;
+import org.sonatype.nexus.repository.storage.TempBlob;
+
+public class PackParser
+        extends org.eclipse.jgit.transport.PackParser
+{
+    private final TempBlob pack_blob;
+
+    private InputStream pack_stream;
+
+    private final ObjectInserter inserter;
+
+    private final ObjectReader reader;
+
+    /** CRC-32 computation for objects that are appended onto the pack. */
+    private final CRC32 crc = new CRC32();
+
+    /** Checksum of the entire pack file. */
+    private final MessageDigest packDigest = Constants.newMessageDigest();
+
+    PackParser(Repository db, TempBlob pack_blob) {
+        super(db.getObjectDatabase(), pack_blob.get());
+        this.inserter = db.newObjectInserter();
+        this.reader = db.newObjectReader();
+        this.pack_blob = pack_blob;
+        this.pack_stream = pack_blob.get();
+    }
+
+    @Override
+    public PackLock parse(ProgressMonitor receiving, ProgressMonitor resolving) throws IOException {
+        super.parse(receiving, resolving);
+
+        // For any object that wasn't inflated during pack parsing, do so now so
+        // all objects from the pack are inserted into the database.
+        for (PackedObjectInfo info : this.getSortedObjectList(null)) {
+            if (!this.reader.has(info)) {
+                InputStream packed_obj = pack_blob.get();
+                packed_obj.skip(info.getOffset());
+                PackedObjectHeader header = new PackedObjectHeader(packed_obj);
+                inserter.insert(header.getType(), header.getObjectSize(), new InflaterInputStream(packed_obj));
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    protected void onPackHeader(long objCount) throws IOException {
+    }
+
+    @Override
+    protected void onBeginWholeObject(long streamPosition, int type, long inflatedSize) throws IOException {
+        this.crc.reset();
+    }
+
+    @Override
+    protected void onEndWholeObject(PackedObjectInfo info) throws IOException {
+        info.setCRC((int) crc.getValue());
+    }
+
+    @Override
+    protected void onBeginOfsDelta(long deltaStreamPosition,
+                                   long baseStreamPosition,
+                                   long inflatedSize) throws IOException
+    {
+        this.crc.reset();
+    }
+
+    @Override
+    protected void onBeginRefDelta(long deltaStreamPosition, AnyObjectId baseId, long inflatedSize) throws IOException {
+        this.crc.reset();
+    }
+
+    @Override
+    protected UnresolvedDelta onEndDelta() throws IOException {
+        UnresolvedDelta delta = new UnresolvedDelta();
+        delta.setCRC((int) this.crc.getValue());
+        return delta;
+    }
+
+    @Override
+    protected void onInflatedObjectData(PackedObjectInfo obj, int type_code, byte[] data) throws IOException {
+        // Small objects and deltas will be fully inflated and resolved as the
+        // pack is read. Since that work is already done for us, insert the
+        // inflated object into the database.
+        this.inserter.insert(type_code, data);
+    }
+
+    @Override
+    protected void onObjectHeader(Source src, byte[] raw, int pos, int len) throws IOException {
+        this.crc.update(raw, pos, len);
+    }
+
+    @Override
+    protected void onObjectData(Source src, byte[] raw, int pos, int len) throws IOException {
+        this.crc.update(raw, pos, len);
+    }
+
+    @Override
+    protected void onStoreStream(byte[] raw, int pos, int len) throws IOException {
+        // Objects are being stored individually so only the pack hash needs to be updated.
+        packDigest.update(raw, pos, len);
+    }
+
+    @Override
+    protected void onPackFooter(byte[] hash) throws IOException {
+        if (!Arrays.equals(packDigest.digest(), hash)) {
+            throw new IOException("Received corrupt pack");
+        }
+    }
+
+    @Override
+    protected ObjectTypeAndSize seekDatabase(PackedObjectInfo obj, ObjectTypeAndSize info) throws IOException {
+        crc.reset();
+        this.pack_stream = this.pack_blob.get();
+        this.pack_stream.skip(obj.getOffset());
+        return readObjectHeader(info);
+    }
+
+    @Override
+    protected ObjectTypeAndSize seekDatabase(UnresolvedDelta delta, ObjectTypeAndSize info) throws IOException {
+        crc.reset();
+        this.pack_stream = this.pack_blob.get();
+        this.pack_stream.skip(delta.getOffset());
+        return readObjectHeader(info);
+    }
+
+    @Override
+    protected int readDatabase(byte[] dst, int pos, int cnt) throws IOException {
+        return this.pack_stream.read(dst, pos, cnt);
+    }
+
+    @Override
+    protected boolean checkCRC(int oldCRC) {
+        return oldCRC == (int) crc.getValue();
+    }
+
+    @Override
+    protected boolean onAppendBase(int typeCode, byte[] data, PackedObjectInfo info) throws IOException {
+        return false;
+    }
+
+    @Override
+    protected void onEndThinPack() throws IOException {
+        // Ignored.
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/PackParser.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/PackParser.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.zip.CRC32;
 import java.util.zip.InflaterInputStream;
 
+import org.sonatype.nexus.repository.view.payloads.TempBlob;
+
 import org.eclipse.jgit.internal.storage.file.PackLock;
 import org.eclipse.jgit.lib.AnyObjectId;
 import org.eclipse.jgit.lib.Constants;
@@ -27,7 +29,6 @@ import org.eclipse.jgit.lib.ObjectInserter;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.ProgressMonitor;
 import org.eclipse.jgit.transport.PackedObjectInfo;
-import org.sonatype.nexus.repository.storage.TempBlob;
 
 public class PackParser
         extends org.eclipse.jgit.transport.PackParser

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/PackedObjectHeader.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/PackedObjectHeader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class PackedObjectHeader
+{
+    private final int type_code;
+
+    private long size;
+
+    public PackedObjectHeader(InputStream src) throws IOException {
+        int c = src.read();
+
+        this.type_code = (c >> 4) & 7;
+        this.size = c & 15;
+
+        int shift = 4;
+        while ((c & 0x80) != 0) {
+            c = src.read();
+            this.size += ((long) (c & 0x7f)) << shift;
+            shift += 7;
+        }
+    }
+
+    public int getType() {
+        return this.type_code;
+    }
+
+    public long getObjectSize() {
+        return this.size;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/RefDatabase.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/RefDatabase.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.annotations.NonNull;
+import org.eclipse.jgit.lib.ObjectIdRef;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.SymbolicRef;
+import org.eclipse.jgit.revwalk.RevObject;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindRefAttributes;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+
+public class RefDatabase
+        extends org.eclipse.jgit.lib.RefDatabase
+{
+    private final Repository db;
+
+    private final AssetKindRefAttributes asset_attributes;
+
+    private final Bucket bucket;
+
+    private final Component component;
+
+    @Inject
+    RefDatabase(Repository db) {
+        this.db = db;
+        this.asset_attributes = db.getAssetAttributesRef();
+        this.bucket = db.getBucket();
+        this.component = db.getComponent();
+    }
+
+    @Override
+    public void create() throws IOException {
+        // Nothing to do.
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do.
+    }
+
+    @Override
+    public Ref exactRef(String name) throws IOException {
+        Asset asset = asset_attributes.findRefAssetWithName(this.bucket, this.component, name);
+        if (asset == null)
+            return null;
+
+        return asset_attributes.getRef(this.bucket, this.component, asset);
+    }
+
+    @Override
+    public Ref getRef(String name) throws IOException {
+        for (String prefix : SEARCH_PATH) {
+            Ref ref = exactRef(prefix + name);
+            if (ref != null)
+                return ref;
+        }
+        return null;
+    }
+
+    @Override
+    @TransactionalTouchMetadata
+    public Map<String, Ref> getRefs(String prefix) throws IOException {
+        Map<String, Ref> refsByName = new HashMap<>();
+        for (Asset asset : asset_attributes.browseRefAssetsByPrefix(this.bucket, this.component, prefix)) {
+            Ref ref = asset_attributes.getRef(this.bucket, this.component, asset);
+            if (ref != null)
+                refsByName.put(StringUtils.remove(asset.name(), prefix), ref);
+        }
+
+        return refsByName;
+    }
+
+    @Override
+    @NonNull
+    @TransactionalTouchMetadata
+    public List<Ref> getRefsByPrefix(String prefix) throws IOException {
+        List<Ref> refs = new ArrayList<Ref>();
+        for (Asset asset : asset_attributes.browseRefAssetsByPrefix(this.bucket, this.component, prefix)) {
+            Ref ref = asset_attributes.getRef(this.bucket, this.component, asset);
+            if (ref != null)
+                refs.add(ref);
+        }
+        return refs;
+    }
+
+    @Override
+    public RefUpdate newUpdate(String name, boolean detach) throws IOException {
+        boolean detachingSymbolicRef = false;
+        Ref ref = exactRef(name);
+        if (ref == null)
+            ref = new ObjectIdRef.Unpeeled(Ref.Storage.NEW, name, null);
+        else
+            detachingSymbolicRef = detach && ref.isSymbolic();
+
+        RefUpdate update = new RefUpdate(this.db, ref);
+        if (detachingSymbolicRef)
+            update.setDetachingSymbolicRef();
+
+        return update;
+    }
+
+    @Override
+    public RefRename newRename(String from_name, String to_name) throws IOException {
+        RefUpdate src = newUpdate(from_name, true);
+        RefUpdate dst = newUpdate(to_name, true);
+        return new RefRename(src, dst);
+    }
+
+    @Override
+    public Ref peel(Ref ref) throws IOException {
+        final Ref leaf = ref.getLeaf();
+        if (leaf.isPeeled() || leaf.getObjectId() == null)
+            return ref;
+
+        ObjectIdRef newLeaf = null;
+        try (RevWalk rw = new RevWalk(this.db)) {
+            RevObject obj = rw.parseAny(leaf.getObjectId());
+            if (obj instanceof RevTag) {
+                newLeaf = new ObjectIdRef.PeeledTag(leaf.getStorage(), leaf.getName(), leaf.getObjectId(),
+                        rw.peel(obj).copy());
+            }
+            else {
+                newLeaf = new ObjectIdRef.PeeledNonTag(leaf.getStorage(), leaf.getName(), leaf.getObjectId());
+            }
+        }
+
+        return recreate(ref, newLeaf);
+    }
+
+    private static Ref recreate(Ref old, ObjectIdRef leaf) {
+        if (old.isSymbolic()) {
+            Ref dst = recreate(old.getTarget(), leaf);
+            return new SymbolicRef(old.getName(), dst);
+        }
+        return leaf;
+    }
+
+    @Override
+    public List<Ref> getAdditionalRefs() throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isNameConflicting(String name) throws IOException {
+        // Cannot be nested within an existing reference.
+        int lastSlash = name.lastIndexOf('/');
+        while (0 < lastSlash) {
+            String needle = name.substring(0, lastSlash);
+            if (asset_attributes.findRefAssetWithName(this.bucket, this.component, needle) != null)
+                return true;
+            lastSlash = name.lastIndexOf('/', lastSlash - 1);
+        }
+
+        // Cannot be the container of an existing reference.
+        String prefix = name + '/';
+        if (getRefsByPrefix(prefix).size() != 0)
+            return true;
+
+        return false;
+    }
+
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/RefRename.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/RefRename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.lib.RefUpdate.Result;
+
+public class RefRename
+        extends org.eclipse.jgit.lib.RefRename
+{
+    RefRename(RefUpdate src, RefUpdate dst) {
+        super(src, dst);
+    }
+
+    @Override
+    protected Result doRename() throws IOException {
+        destination.setExpectedOldObjectId(ObjectId.zeroId());
+        destination.setNewObjectId(source.getRef().getObjectId());
+        switch (destination.update()) {
+            case NEW:
+                source.delete();
+                return Result.RENAMED;
+
+            default:
+                return destination.getResult();
+        }
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/RefUpdate.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/RefUpdate.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.lib.ObjectIdRef;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.SymbolicRef;
+import org.eclipse.jgit.revwalk.RevObject;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindRefAttributes;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+public class RefUpdate
+        extends org.eclipse.jgit.lib.RefUpdate
+{
+    private final Repository db;
+
+    private final AssetKindRefAttributes asset_attributes;
+
+    private final Bucket bucket;
+
+    private final Component component;
+
+    private Ref dstRef;
+
+    private RevWalk rw;
+
+    RefUpdate(Repository db, Ref ref) {
+        super(ref);
+        this.db = db;
+        this.asset_attributes = db.getAssetAttributesRef();
+        this.bucket = db.getBucket();
+        this.component = db.getComponent();
+    }
+
+    @Override
+    protected RefDatabase getRefDatabase() {
+        return this.db.getRefDatabase();
+    }
+
+    @Override
+    protected Repository getRepository() {
+        return this.db;
+    }
+
+    @Override
+    protected boolean tryLock(boolean deref) throws IOException {
+        dstRef = getRef();
+        if (deref)
+            dstRef = dstRef.getLeaf();
+
+        if (dstRef.isSymbolic())
+            setOldObjectId(null);
+        else
+            setOldObjectId(dstRef.getObjectId());
+
+        return true;
+    }
+
+    @Override
+    protected void unlock() {
+        // No state is held while "locked".
+    }
+
+    @Override
+    public Result update(RevWalk walk) throws IOException {
+        // RevUpdate is needed in doUpdate() but is not available there.
+        try {
+            rw = walk;
+            return super.update(walk);
+        }
+        finally {
+            rw = null;
+        }
+    }
+
+    @Override
+    @TransactionalStoreMetadata
+    protected Result doUpdate(Result desired_result) throws IOException {
+        ObjectIdRef newRef;
+        RevObject obj = rw.parseAny(getNewObjectId());
+        if (obj instanceof RevTag) {
+            newRef = new ObjectIdRef.PeeledTag(Ref.Storage.LOOSE, dstRef.getName(), getNewObjectId(),
+                    rw.peel(obj).copy());
+        }
+        else {
+            newRef = new ObjectIdRef.PeeledNonTag(Ref.Storage.LOOSE, dstRef.getName(), getNewObjectId());
+        }
+
+        StorageTx tx = UnitOfWork.currentTx();
+        Asset asset = asset_attributes.findRefAssetWithName(this.bucket, this.component, dstRef.getName());
+        if (asset == null) {
+            asset = asset_attributes.createRefAsset(this.bucket, this.component, dstRef.getName());
+        }
+        asset_attributes.setRef(asset, newRef);
+        tx.saveAsset(asset);
+
+        return desired_result;
+    }
+
+    @Override
+    @TransactionalStoreMetadata
+    protected Result doLink(String target) throws IOException {
+        final SymbolicRef newRef =
+                new SymbolicRef(dstRef.getName(), new ObjectIdRef.Unpeeled(Ref.Storage.NEW, target, null));
+
+        StorageTx tx = UnitOfWork.currentTx();
+        Asset asset = asset_attributes.findRefAssetWithName(this.bucket, this.component, dstRef.getName());
+        if (asset == null) {
+            asset = asset_attributes.createRefAsset(this.bucket, this.component, dstRef.getName());
+        }
+        asset_attributes.setRef(asset, newRef);
+        tx.saveAsset(asset);
+
+        if (dstRef.getStorage() == Ref.Storage.NEW) {
+            return Result.NEW;
+        }
+        else {
+            return Result.FORCED;
+        }
+    }
+
+    @Override
+    @TransactionalStoreMetadata
+    protected Result doDelete(Result desired_result) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+        Asset asset = asset_attributes.findRefAssetWithName(this.bucket, this.component, dstRef.getName());
+        if (asset == null)
+            return Result.REJECTED_MISSING_OBJECT;
+
+        tx.deleteAsset(asset);
+
+        return desired_result;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/Repository.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/Repository.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.eclipse.jgit.lib.BaseRepositoryBuilder;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ReflogReader;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindConfigAttributes;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindObjectAttributes;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindRefAttributes;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+
+/*
+ * Provides a Git Repository implemented atop StorageFace. Git repositories primarily consist of two
+ * datastores: the object database and the ref database. Traditional Git implements boths of these
+ * using filesystem constructs. Since Nexus uses an asset database and blob store, the traditional
+ * repository representation does not map well. GitStorageFacetRepository instances
+ * GitStorageFacetObjectDatabase and GitStorageFacetRefDatabase to implmement these databases on
+ * Nexus Assets.
+ */
+
+public class Repository
+        extends org.eclipse.jgit.lib.Repository
+{
+    @Named
+    public static class Builder
+            extends BaseRepositoryBuilder<Builder, Repository>
+    {
+        private final AssetKindConfigAttributes asset_attributes_config;
+
+        private final AssetKindObjectAttributes asset_attributes_object;
+
+        private final AssetKindRefAttributes asset_attributes_ref;
+
+        private StorageFacet storage_facet;
+
+        private Bucket bucket;
+
+        private Component component;
+
+        @Inject
+        public Builder(AssetKindConfigAttributes asset_attributes_config,
+                       AssetKindObjectAttributes asset_attributes_object,
+                       AssetKindRefAttributes asset_attributes_ref)
+        {
+            setBare();
+            this.asset_attributes_config = asset_attributes_config;
+            this.asset_attributes_object = asset_attributes_object;
+            this.asset_attributes_ref = asset_attributes_ref;
+        }
+
+        public Builder setStorageFacet(StorageFacet storage_facet) {
+            this.storage_facet = storage_facet;
+            return self();
+        }
+
+        public Builder setComponent(Bucket bucket, Component component) {
+            this.bucket = bucket;
+            this.component = component;
+            return self();
+        }
+
+        @Override
+        public Repository build() throws IOException {
+
+            return new Repository(this);
+        }
+    }
+
+    private final AssetKindConfigAttributes asset_attributes_config;
+
+    private final AssetKindObjectAttributes asset_attributes_object;
+
+    private final AssetKindRefAttributes asset_attributes_ref;
+
+    private final StorageFacet storage_facet;
+
+    private final StoredConfig config;
+
+    private final ObjectDatabase obj_db;
+
+    private final RefDatabase ref_db;
+
+    Bucket bucket;
+
+    Component component;
+
+    public Repository(Builder builder) {
+        super(builder);
+        this.asset_attributes_config = builder.asset_attributes_config;
+        this.asset_attributes_object = builder.asset_attributes_object;
+        this.asset_attributes_ref = builder.asset_attributes_ref;
+        this.storage_facet = builder.storage_facet;
+        this.bucket = builder.bucket;
+        this.component = builder.component;
+
+        this.config = new StoredConfig(this);
+        this.obj_db = new ObjectDatabase(this);
+        this.ref_db = new RefDatabase(this);
+    }
+
+    AssetKindConfigAttributes getAssetAttributesConfig() {
+        return this.asset_attributes_config;
+    }
+
+    AssetKindObjectAttributes getAssetAttributesObject() {
+        return this.asset_attributes_object;
+    }
+
+    AssetKindRefAttributes getAssetAttributesRef() {
+        return this.asset_attributes_ref;
+    }
+
+    StorageFacet getStorageFacet() {
+        return this.storage_facet;
+    }
+
+    Bucket getBucket() {
+        return this.bucket;
+    }
+
+    Component getComponent() {
+        return this.component;
+    }
+
+    @Override
+    public void create(boolean bare) throws IOException {
+        String master = Constants.R_HEADS + Constants.MASTER;
+        RefUpdate.Result result = updateRef(Constants.HEAD, true).link(master);
+        if (result != RefUpdate.Result.NEW)
+            throw new IOException(result.name());
+    }
+
+    @Override
+    public StoredConfig getConfig() {
+        return this.config;
+    }
+
+    @Override
+    public RefDatabase getRefDatabase() {
+        return this.ref_db;
+    }
+
+    @Override
+    public ObjectDatabase getObjectDatabase() {
+        return this.obj_db;
+    }
+
+    @Override
+    public ReflogReader getReflogReader(String refName) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void notifyIndexChanged(boolean internal) {
+        // Do not send notifications.
+        // There is no index, as there is no working tree.
+    }
+
+    @Override
+    public void scanForRepoChanges() throws IOException {
+        this.ref_db.refresh();
+    }
+
+    @Override
+    public AttributesNodeProvider createAttributesNodeProvider() {
+        return new AttributesNodeProvider();
+    }
+
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/StoredConfig.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/repo/StoredConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.git.repo;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.jgit.errors.ConfigInvalidException;
+import org.sonatype.nexus.plugins.cargo.git.assets.AssetKindConfigAttributes;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+
+public class StoredConfig
+        extends org.eclipse.jgit.lib.StoredConfig
+{
+    private final AssetKindConfigAttributes asset_attributes;
+
+    private final Bucket repo_bucket;
+
+    private final Component repo_component;
+
+    StoredConfig(Repository db) {
+        super();
+        this.asset_attributes = db.getAssetAttributesConfig();
+        this.repo_bucket = db.getBucket();
+        this.repo_component = db.getComponent();
+    }
+
+    @Override
+    public void save() throws IOException {
+        Asset asset = asset_attributes.findConfigAsset(this.repo_bucket, this.repo_component);
+        if (asset == null) {
+            asset = asset_attributes.createConfigAsset(this.repo_bucket, this.repo_component);
+        }
+        asset_attributes.setContents(asset, IOUtils.toInputStream(this.toText(), StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void load() throws IOException, ConfigInvalidException {
+        // If the asset or blob doesn't exist, StoredConfig expects a blank
+        // config as if an empty config had been stored.
+        clear();
+
+        Asset asset = asset_attributes.findConfigAsset(this.repo_bucket, this.repo_component);
+        if (asset != null) {
+            fromText(IOUtils.toString(asset_attributes.getContents(asset), StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.hosted;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.plugins.cargo.CargoFormat;
+import org.sonatype.nexus.plugins.cargo.CargoRecipeSupport;
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.Type;
+import org.sonatype.nexus.repository.http.HttpHandlers;
+import org.sonatype.nexus.repository.http.HttpMethods;
+import org.sonatype.nexus.repository.http.HttpResponses;
+import org.sonatype.nexus.repository.types.HostedType;
+import org.sonatype.nexus.repository.view.ConfigurableViewFacet;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Handler;
+import org.sonatype.nexus.repository.view.Response;
+import org.sonatype.nexus.repository.view.Route;
+import org.sonatype.nexus.repository.view.Router;
+import org.sonatype.nexus.repository.view.ViewFacet;
+import org.sonatype.nexus.repository.view.matchers.ActionMatcher;
+
+@Named(CargoHostedRecipe.NAME)
+@Singleton
+class CargoHostedRecipe
+        extends CargoRecipeSupport
+{
+    public static final String NAME = "cargo-hosted";
+
+    @Inject
+    CargoHostedRecipe(@Named(HostedType.NAME) final Type type, @Named(CargoFormat.NAME) final Format format) {
+        super(type, format);
+    }
+
+    @Override
+    public void apply(Repository repository) throws Exception {
+        repository.attach(securityFacet.get());
+        repository.attach(configure(viewFacet.get()));
+        repository.attach(storageFacet.get());
+        repository.attach(searchFacet.get());
+        repository.attach(attributesFacet.get());
+        repository.attach(componentMaintenanceFacet.get());
+    }
+
+    private ViewFacet configure(final ConfigurableViewFacet facet) {
+        Router.Builder builder = new Router.Builder();
+
+        builder.route(new Route.Builder().matcher(new ActionMatcher(HttpMethods.GET)).handler(timingHandler)
+                .handler(securityHandler).handler(exceptionHandler).handler(conditionalRequestHandler)
+                .handler(partialFetchHandler).handler(contentHeadersHandler).handler(unitOfWorkHandler)
+                .handler(new Handler()
+                {
+
+                    @Override
+                    public Response handle(Context context) throws Exception {
+                        return HttpResponses.notImplemented(context.toString());
+                    }
+                }).create());
+
+        builder.defaultHandlers(HttpHandlers.notFound());
+        facet.configure(builder.create());
+        return facet;
+    }
+
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
@@ -19,6 +19,7 @@ import javax.inject.Singleton;
 
 import org.sonatype.nexus.plugins.cargo.CargoFormat;
 import org.sonatype.nexus.plugins.cargo.CargoRecipeSupport;
+import org.sonatype.nexus.plugins.cargo.git.GitRepositoryHandlers;
 import org.sonatype.nexus.repository.Format;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.Type;
@@ -34,6 +35,7 @@ import org.sonatype.nexus.repository.view.Route;
 import org.sonatype.nexus.repository.view.Router;
 import org.sonatype.nexus.repository.view.ViewFacet;
 import org.sonatype.nexus.repository.view.matchers.ActionMatcher;
+import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
 
 @Named(CargoHostedRecipe.NAME)
 @Singleton
@@ -41,6 +43,18 @@ class CargoHostedRecipe
         extends CargoRecipeSupport
 {
     public static final String NAME = "cargo-hosted";
+
+    @Inject
+    protected GitRepositoryHandlers.Default gitDefaultHandler;
+
+    @Inject
+    protected GitRepositoryHandlers.InfoRefs gitInfoRefsHandler;
+
+    @Inject
+    protected GitRepositoryHandlers.ReceivePackService gitReceivePackHandler;
+
+    @Inject
+    protected GitRepositoryHandlers.UploadPackService gitUploadPackHandler;
 
     @Inject
     CargoHostedRecipe(@Named(HostedType.NAME) final Type type, @Named(CargoFormat.NAME) final Format format) {
@@ -60,6 +74,30 @@ class CargoHostedRecipe
     private ViewFacet configure(final ConfigurableViewFacet facet) {
         Router.Builder builder = new Router.Builder();
 
+        // Git HTTP protocol reference discovery
+        builder.route(new Route.Builder().matcher(new TokenMatcher("/{repo_name:index}/info/refs"))
+                .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
+                .handler(conditionalRequestHandler).handler(contentHeadersHandler).handler(unitOfWorkHandler)
+                .handler(gitInfoRefsHandler).create());
+
+        // Git client fetching objects over Smart HTTP protocol
+        builder.route(new Route.Builder().matcher(new TokenMatcher("/{repo_name:index}/git-upload-pack"))
+                .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
+                .handler(conditionalRequestHandler).handler(contentHeadersHandler).handler(unitOfWorkHandler)
+                .handler(gitUploadPackHandler).create());
+
+        // Git client pushing objects over Smart HTTP protocol
+        builder.route(new Route.Builder().matcher(new TokenMatcher("/{repo_name:index}/git-receive-pack"))
+                .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
+                .handler(conditionalRequestHandler).handler(contentHeadersHandler).handler(unitOfWorkHandler)
+                .handler(gitUploadPackHandler).create());
+
+        // 404 anything else inside the index Git repo
+        builder.route(new Route.Builder().matcher(new TokenMatcher("/{repo_name:index}/.*")).handler(timingHandler)
+                .handler(securityHandler).handler(exceptionHandler).handler(conditionalRequestHandler)
+                .handler(contentHeadersHandler).handler(unitOfWorkHandler).handler(gitDefaultHandler).create());
+
+        // Crates.io API v1
         builder.route(new Route.Builder().matcher(new ActionMatcher(HttpMethods.GET)).handler(timingHandler)
                 .handler(securityHandler).handler(exceptionHandler).handler(conditionalRequestHandler)
                 .handler(partialFetchHandler).handler(contentHeadersHandler).handler(unitOfWorkHandler)

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/CargoRegistryFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/CargoRegistryFacetImpl.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.registry;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.validation.constraints.NotNull;
+import javax.validation.groups.Default;
+
+import com.google.common.eventbus.Subscribe;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import org.eclipse.jgit.dircache.DirCache;
+import org.eclipse.jgit.dircache.DirCacheBuilder;
+import org.eclipse.jgit.dircache.DirCacheEditor;
+import org.eclipse.jgit.dircache.DirCacheEntry;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.CommitBuilder;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.sonatype.nexus.email.EmailManager;
+import org.sonatype.nexus.plugins.cargo.CargoRegistryFacet;
+import org.sonatype.nexus.plugins.cargo.CrateCoordinates;
+import org.sonatype.nexus.plugins.cargo.GitRepositoryFacet;
+import org.sonatype.nexus.plugins.cargo.registry.assets.AssetKindMetadataAttributes;
+import org.sonatype.nexus.plugins.cargo.registry.assets.AssetKindTarballAttributes;
+import org.sonatype.nexus.plugins.cargo.registry.assets.ComponentKindCrateAttributes;
+import org.sonatype.nexus.repository.FacetSupport;
+import org.sonatype.nexus.repository.RepositoryStartedEvent;
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.config.ConfigurationFacet;
+import org.sonatype.nexus.repository.http.HttpResponses;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.StorageFacet;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.repository.types.HostedType;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.Response;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+/**
+ * A {@link CargoRegistryFacet} that persists Cargo crates and metadata via {@link StorageFacet}.
+ */
+
+@Named
+public class CargoRegistryFacetImpl
+        extends FacetSupport
+        implements CargoRegistryFacet
+{
+    private final EmailManager emailManager;
+
+    private final ComponentKindCrateAttributes crateAttributes;
+
+    private final AssetKindTarballAttributes tarballAttributes;
+
+    private final AssetKindMetadataAttributes metadataAttributes;
+
+    private final String indexBranch = Constants.R_HEADS + Constants.MASTER;
+
+    static final String CONFIG_KEY = "cargo";
+
+    static class Config
+    {
+        @NotNull(groups = {HostedType.ValidationGroup.class})
+        // @Url(groups = { HostedType.ValidationGroup.class })
+        public URI allowedRegistries;
+    }
+
+    private Config config;
+
+    @Inject
+    protected CargoRegistryFacetImpl(EmailManager emailManager,
+                                     ComponentKindCrateAttributes crateAttributes,
+                                     AssetKindTarballAttributes tarballAttributes,
+                                     AssetKindMetadataAttributes metadataAttributes)
+    {
+        this.emailManager = emailManager;
+        this.crateAttributes = crateAttributes;
+        this.tarballAttributes = tarballAttributes;
+        this.metadataAttributes = metadataAttributes;
+    }
+
+    @Override
+    protected void doValidate(final Configuration configuration) throws Exception {
+        facet(ConfigurationFacet.class).validateSection(configuration, CONFIG_KEY, Config.class, Default.class,
+                getRepository().getType().getValidationGroup());
+    }
+
+    @Override
+    protected void doConfigure(final Configuration configuration) throws Exception {
+        config = facet(ConfigurationFacet.class).readSection(configuration, CONFIG_KEY, Config.class);
+    }
+
+    @Override
+    protected void doDestroy() throws Exception {
+        config = null;
+    }
+
+    @Subscribe
+    public void initializeGitRepo(RepositoryStartedEvent event) throws IOException {
+        UnitOfWork.begin(this.getRepository().facet(StorageFacet.class).txSupplier());
+        // Create a git repo if one doesn't already exist.
+        GitRepositoryFacet gitFacet = this.getRepository().facet(GitRepositoryFacet.class);
+        Repository indexRepo = gitFacet.getGitRepository("index");
+        if (indexRepo == null) {
+            indexRepo = gitFacet.createGitRepository("index");
+        }
+    }
+
+    @Override
+    @TransactionalStoreMetadata
+    @TransactionalStoreBlob
+    public void writeConfigJson() throws Exception {
+        // Check that the repo URL is known. When a fixed URL is not set, the
+        // URL is detected from the request URL and can be null until a request
+        // with a Host header is seen.
+        String requestUrl = this.getRepository().getUrl();
+        if (requestUrl == null)
+            return;
+
+        Repository indexRepo = this.getRepository().facet(GitRepositoryFacet.class).getGitRepository("index");
+
+        // Generate config.json with the current repository URL
+        JsonObject config = new JsonObject();
+        config.addProperty("dl", this.getRepository().getUrl() + "/api/v1/crates");
+        config.addProperty("api", this.getRepository().getUrl());
+        JsonArray allowedRegistries = new JsonArray();
+        allowedRegistries.add(new JsonPrimitive(this.config.allowedRegistries.toString()));
+        config.add("allowed-registries", allowedRegistries);
+
+        // Calculate the ObjectId for the generated config.json and insert it into the object index.
+        ObjectInserter ins = indexRepo.newObjectInserter();
+        byte[] configBytes = config.toString().getBytes(StandardCharsets.UTF_8);
+        AnyObjectId configObjId = ins.idFor(Constants.OBJ_BLOB, configBytes);
+        ins.insert(Constants.OBJ_BLOB, configBytes);
+        ins.flush();
+
+        // Start with a blank tree.
+        DirCache dirCache = DirCache.newInCore();
+        RevCommit parent = null;
+
+        // If there is a current HEAD, read that commit's tree. It will become
+        // our parent.
+        AnyObjectId headId = indexRepo.resolve(this.indexBranch + "^{commit}"); //$NON-NLS-1$
+        if (headId != null) {
+            try (RevWalk revWalk = new RevWalk(indexRepo)) {
+                parent = revWalk.parseCommit(headId);
+                DirCacheBuilder builder = dirCache.builder();
+                builder.addTree(null, DirCacheEntry.STAGE_0, indexRepo.newObjectReader(), parent.getTree());
+                builder.finish();
+            }
+        }
+
+        // Update config.json in the tree to point to the correct ObjectId.
+        DirCacheEditor editor = dirCache.editor();
+        editor.add(new DirCacheEditor.PathEdit("config.json")
+        {
+            @Override
+            public void apply(DirCacheEntry ent) {
+                ent.setFileMode(FileMode.REGULAR_FILE);
+                ent.setObjectId(configObjId);
+            }
+        });
+        editor.finish();
+        AnyObjectId indexTreeId = dirCache.writeTree(ins);
+
+        // Check for empty commits
+        if (parent != null && indexTreeId.equals(parent.getTree())) {
+            return;
+        }
+
+        // Create a Commit object, populate it and write it
+        PersonIdent adminIdent = new PersonIdent("Nexus System", this.emailManager.getConfiguration().getFromAddress());
+        CommitBuilder commit = new CommitBuilder();
+        commit.setCommitter(adminIdent);
+        commit.setAuthor(adminIdent);
+        commit.setMessage("Update registry URL to " + this.getRepository().getUrl());
+        if (parent != null) {
+            commit.setParentIds(parent);
+        }
+        commit.setTreeId(indexTreeId);
+        AnyObjectId commitId = ins.insert(commit);
+        ins.flush();
+
+        try (RevWalk revWalk = new RevWalk(indexRepo)) {
+            RevCommit revCommit = revWalk.parseCommit(commitId);
+            RefUpdate headUpdate = indexRepo.updateRef(this.indexBranch);
+            headUpdate.setNewObjectId(commitId);
+            String reflogMsgPrefix = parent == null ? "commit (initial): " : "commit: ";
+            headUpdate.setRefLogMessage(reflogMsgPrefix + revCommit.getShortMessage(), false);
+
+            if (headId != null)
+                headUpdate.setExpectedOldObjectId(headId);
+            else
+                headUpdate.setExpectedOldObjectId(ObjectId.zeroId());
+            headUpdate.forceUpdate();
+        }
+    }
+
+    @Override
+    @TransactionalStoreMetadata
+    @TransactionalStoreBlob
+    public Response publishCrate(CrateCoordinates crateId,
+                                 JsonElement metadata,
+                                 InputStream tarball) throws IOException
+    {
+        StorageTx tx = UnitOfWork.currentTx();
+        Bucket bucket = tx.findBucket(this.getRepository());
+
+        // Abort if the request is for an existing crate.
+        Component crateComponent = this.crateAttributes.find(this.getRepository(), crateId);
+        if (crateComponent != null) {
+            return HttpResponses.forbidden("Crate version already exists");
+
+        }
+
+        crateComponent = this.crateAttributes.create(this.getRepository(), crateId);
+
+        this.metadataAttributes.createAsset(bucket, crateComponent,
+                new ByteArrayInputStream(new Gson().toJson(metadata).getBytes(StandardCharsets.UTF_8)));
+        this.tarballAttributes.createAsset(bucket, crateComponent, tarball);
+
+        return HttpResponses.ok();
+    }
+
+    @Override
+    @TransactionalTouchMetadata
+    @TransactionalTouchBlob
+    public Content downloadMetadata(CrateCoordinates crateId) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        Bucket bucket = tx.findBucket(this.getRepository());
+        Component component = crateAttributes.find(this.getRepository(), crateId);
+        if (component == null) {
+            return null;
+        }
+
+        return metadataAttributes.getAssetContent(bucket, component);
+    }
+
+    @Override
+    @TransactionalTouchMetadata
+    @TransactionalTouchBlob
+    public Content downloadTarball(CrateCoordinates crateId) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        Bucket bucket = tx.findBucket(this.getRepository());
+        Component component = crateAttributes.find(this.getRepository(), crateId);
+        if (component == null)
+            return null;
+
+        return tarballAttributes.getAssetContent(bucket, component);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/CargoRegistryFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/CargoRegistryFacetImpl.java
@@ -31,25 +31,12 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
-import org.eclipse.jgit.dircache.DirCache;
-import org.eclipse.jgit.dircache.DirCacheBuilder;
-import org.eclipse.jgit.dircache.DirCacheEditor;
-import org.eclipse.jgit.dircache.DirCacheEntry;
-import org.eclipse.jgit.lib.AnyObjectId;
-import org.eclipse.jgit.lib.CommitBuilder;
 import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.FileMode;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.ObjectInserter;
-import org.eclipse.jgit.lib.PersonIdent;
-import org.eclipse.jgit.lib.RefUpdate;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevWalk;
 import org.sonatype.nexus.email.EmailManager;
 import org.sonatype.nexus.plugins.cargo.CargoRegistryFacet;
 import org.sonatype.nexus.plugins.cargo.CrateCoordinates;
 import org.sonatype.nexus.plugins.cargo.GitRepositoryFacet;
+import org.sonatype.nexus.plugins.cargo.git.repo.Repository;
 import org.sonatype.nexus.plugins.cargo.registry.assets.AssetKindMetadataAttributes;
 import org.sonatype.nexus.plugins.cargo.registry.assets.AssetKindTarballAttributes;
 import org.sonatype.nexus.plugins.cargo.registry.assets.ComponentKindCrateAttributes;
@@ -151,7 +138,8 @@ public class CargoRegistryFacetImpl
         if (requestUrl == null)
             return;
 
-        Repository indexRepo = this.getRepository().facet(GitRepositoryFacet.class).getGitRepository("index");
+        GitRepositoryFacet gitFacet = this.getRepository().facet(GitRepositoryFacet.class);
+        Repository indexRepo = gitFacet.getGitRepository("index");
 
         // Generate config.json with the current repository URL
         JsonObject config = new JsonObject();
@@ -161,73 +149,8 @@ public class CargoRegistryFacetImpl
         allowedRegistries.add(new JsonPrimitive(this.config.allowedRegistries.toString()));
         config.add("allowed-registries", allowedRegistries);
 
-        // Calculate the ObjectId for the generated config.json and insert it into the object index.
-        ObjectInserter ins = indexRepo.newObjectInserter();
-        byte[] configBytes = config.toString().getBytes(StandardCharsets.UTF_8);
-        AnyObjectId configObjId = ins.idFor(Constants.OBJ_BLOB, configBytes);
-        ins.insert(Constants.OBJ_BLOB, configBytes);
-        ins.flush();
-
-        // Start with a blank tree.
-        DirCache dirCache = DirCache.newInCore();
-        RevCommit parent = null;
-
-        // If there is a current HEAD, read that commit's tree. It will become
-        // our parent.
-        AnyObjectId headId = indexRepo.resolve(this.indexBranch + "^{commit}"); //$NON-NLS-1$
-        if (headId != null) {
-            try (RevWalk revWalk = new RevWalk(indexRepo)) {
-                parent = revWalk.parseCommit(headId);
-                DirCacheBuilder builder = dirCache.builder();
-                builder.addTree(null, DirCacheEntry.STAGE_0, indexRepo.newObjectReader(), parent.getTree());
-                builder.finish();
-            }
-        }
-
-        // Update config.json in the tree to point to the correct ObjectId.
-        DirCacheEditor editor = dirCache.editor();
-        editor.add(new DirCacheEditor.PathEdit("config.json")
-        {
-            @Override
-            public void apply(DirCacheEntry ent) {
-                ent.setFileMode(FileMode.REGULAR_FILE);
-                ent.setObjectId(configObjId);
-            }
-        });
-        editor.finish();
-        AnyObjectId indexTreeId = dirCache.writeTree(ins);
-
-        // Check for empty commits
-        if (parent != null && indexTreeId.equals(parent.getTree())) {
-            return;
-        }
-
-        // Create a Commit object, populate it and write it
-        PersonIdent adminIdent = new PersonIdent("Nexus System", this.emailManager.getConfiguration().getFromAddress());
-        CommitBuilder commit = new CommitBuilder();
-        commit.setCommitter(adminIdent);
-        commit.setAuthor(adminIdent);
-        commit.setMessage("Update registry URL to " + this.getRepository().getUrl());
-        if (parent != null) {
-            commit.setParentIds(parent);
-        }
-        commit.setTreeId(indexTreeId);
-        AnyObjectId commitId = ins.insert(commit);
-        ins.flush();
-
-        try (RevWalk revWalk = new RevWalk(indexRepo)) {
-            RevCommit revCommit = revWalk.parseCommit(commitId);
-            RefUpdate headUpdate = indexRepo.updateRef(this.indexBranch);
-            headUpdate.setNewObjectId(commitId);
-            String reflogMsgPrefix = parent == null ? "commit (initial): " : "commit: ";
-            headUpdate.setRefLogMessage(reflogMsgPrefix + revCommit.getShortMessage(), false);
-
-            if (headId != null)
-                headUpdate.setExpectedOldObjectId(headId);
-            else
-                headUpdate.setExpectedOldObjectId(ObjectId.zeroId());
-            headUpdate.forceUpdate();
-        }
+        gitFacet.replaceFile(indexRepo, this.indexBranch, "config.json",
+                config.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKind.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKind.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.registry.assets;
+
+import javax.annotation.Nonnull;
+
+import org.sonatype.nexus.repository.cache.CacheControllerHolder;
+import org.sonatype.nexus.repository.cache.CacheControllerHolder.CacheType;
+
+public enum AssetKind
+{
+    TARBALL(CacheControllerHolder.CONTENT), METADATA(CacheControllerHolder.METADATA);
+
+    private final CacheType cacheType;
+
+    AssetKind(final CacheType cacheType) {
+        this.cacheType = cacheType;
+    }
+
+    @Nonnull
+    public CacheType getCacheType() {
+        return cacheType;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindMetadataAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindMetadataAttributes.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.registry.assets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Iterables;
+
+import org.sonatype.nexus.blobstore.api.Blob;
+import org.sonatype.nexus.blobstore.api.BlobRef;
+import org.sonatype.nexus.common.hash.HashAlgorithm;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetEntityAdapter;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.BucketEntityAdapter;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.ComponentEntityAdapter;
+import org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter;
+import org.sonatype.nexus.repository.storage.Query;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.payloads.BlobPayload;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class AssetKindMetadataAttributes
+{
+    public static final String CONTENT_TYPE_JSON = "application/json";
+
+    public static final List<HashAlgorithm> HASH_ALGORITHMS = new ArrayList<HashAlgorithm>();
+
+    protected final BucketEntityAdapter bucketEntityAdapter;
+
+    protected final ComponentEntityAdapter componentEntityAdapter;
+
+    protected final ComponentKindCrateAttributes crateAttributes;
+
+    @Inject
+    protected AssetKindMetadataAttributes(BucketEntityAdapter bucketEntityAdapter,
+                                          ComponentEntityAdapter assetEntityAdapter,
+                                          ComponentKindCrateAttributes crateAttributes)
+    {
+        this.bucketEntityAdapter = bucketEntityAdapter;
+        this.componentEntityAdapter = assetEntityAdapter;
+        this.crateAttributes = crateAttributes;
+    }
+
+    private static String getAttributePropertyName(String format_attribute) {
+        return MetadataNodeEntityAdapter.P_ATTRIBUTES + "." + format_attribute;
+    }
+
+    @TransactionalTouchMetadata
+    @TransactionalTouchBlob
+    public Asset createAsset(Bucket bucket, Component component, InputStream metadata) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        Asset asset = tx.createAsset(bucket, component);
+        String filename = crateAttributes.getCoordinates(component).getFileBasename() + ".json";
+        asset.name(filename);
+        asset.attributes().set(AssetEntityAdapter.P_ASSET_KIND, AssetKind.METADATA.name());
+        tx.setBlob(asset, filename, Suppliers.ofInstance(metadata), HASH_ALGORITHMS, null, CONTENT_TYPE_JSON, true);
+        tx.saveAsset(asset);
+
+        return asset;
+    }
+
+    @TransactionalTouchMetadata
+    public Asset findAsset(Bucket bucket, Component component) {
+        StorageTx tx = UnitOfWork.currentTx();
+        Iterable<Asset> objAssets = tx.findAssets(Query.builder().where(AssetEntityAdapter.P_BUCKET)
+                .eq(bucketEntityAdapter.recordIdentity(bucket)).and(AssetEntityAdapter.P_COMPONENT)
+                .eq(componentEntityAdapter.recordIdentity(component))
+                .and(getAttributePropertyName(AssetEntityAdapter.P_ASSET_KIND)).eq(AssetKind.METADATA.name()).build(),
+                null);
+        return Iterables.getOnlyElement(objAssets, null);
+    }
+
+    @TransactionalTouchBlob
+    public Content getAssetContent(Bucket bucket, Component component) {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        final Asset asset = findAsset(bucket, component);
+        if (asset == null)
+            return null;
+
+        BlobRef blobref = asset.blobRef();
+        if (blobref == null)
+            return null;
+
+        final Blob blob = tx.requireBlob(blobref);
+        if (blob == null)
+            return null;
+
+        if (asset.markAsDownloaded()) {
+            tx.saveAsset(asset);
+        }
+
+        final String contentType = asset.contentType();
+        final Content content = new Content(new BlobPayload(blob, contentType));
+        Content.extractFromAsset(asset, HASH_ALGORITHMS, content.getAttributes());
+        return content;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindTarballAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindTarballAttributes.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.registry.assets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import org.sonatype.nexus.blobstore.api.Blob;
+import org.sonatype.nexus.blobstore.api.BlobRef;
+import org.sonatype.nexus.common.hash.HashAlgorithm;
+import org.sonatype.nexus.repository.storage.Asset;
+import org.sonatype.nexus.repository.storage.AssetEntityAdapter;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.BucketEntityAdapter;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.ComponentEntityAdapter;
+import org.sonatype.nexus.repository.storage.MetadataNodeEntityAdapter;
+import org.sonatype.nexus.repository.storage.Query;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.payloads.BlobPayload;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class AssetKindTarballAttributes
+{
+    public static final String CONTENT_TYPE_TARBALL = "application/x-tar";
+
+    public static final List<HashAlgorithm> HASH_ALGORITHMS = Lists.newArrayList(HashAlgorithm.SHA1);
+
+    protected final BucketEntityAdapter bucketEntityAdapter;
+
+    protected final ComponentEntityAdapter componentEntityAdapter;
+
+    protected final ComponentKindCrateAttributes crateAttributes;
+
+    @Inject
+    protected AssetKindTarballAttributes(BucketEntityAdapter bucketEntityAdapter,
+                                         ComponentEntityAdapter componentEntityAdapter,
+                                         ComponentKindCrateAttributes crateAttributes)
+    {
+        this.bucketEntityAdapter = bucketEntityAdapter;
+        this.componentEntityAdapter = componentEntityAdapter;
+        this.crateAttributes = crateAttributes;
+    }
+
+    private static String getAttributePropertyName(String format_attribute) {
+        return MetadataNodeEntityAdapter.P_ATTRIBUTES + "." + format_attribute;
+    }
+
+    /*
+     * Creates an asset to hold a specific crate version's tarball. Caller is expected to attach a
+     * blob containing tarball payload.
+     */
+    @TransactionalTouchMetadata
+    @TransactionalTouchBlob
+    public Asset createAsset(Bucket bucket, Component component, InputStream tarball) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        // Create an Asset to hold the new version.
+        Asset asset = tx.createAsset(bucket, component);
+        String tarballName = crateAttributes.getCoordinates(component).getFileBasename() + ".crate";
+        asset.name(tarballName);
+        asset.attributes().set(AssetEntityAdapter.P_ASSET_KIND, AssetKind.TARBALL.name());
+        tx.setBlob(asset, tarballName, Suppliers.ofInstance(tarball), HASH_ALGORITHMS, null, CONTENT_TYPE_TARBALL,
+                true);
+        tx.saveAsset(asset);
+
+        return asset;
+    }
+
+    @TransactionalTouchMetadata
+    public Asset findAsset(Bucket bucket, Component component) {
+        StorageTx tx = UnitOfWork.currentTx();
+        Iterable<Asset> objAssets = tx.findAssets(Query.builder().where(AssetEntityAdapter.P_BUCKET)
+                .eq(bucketEntityAdapter.recordIdentity(bucket)).and(AssetEntityAdapter.P_COMPONENT)
+                .eq(componentEntityAdapter.recordIdentity(component))
+                .and(getAttributePropertyName(AssetEntityAdapter.P_ASSET_KIND)).eq(AssetKind.TARBALL.name()).build(),
+                null);
+        return Iterables.getOnlyElement(objAssets, null);
+    }
+
+    @TransactionalTouchBlob
+    public Content getAssetContent(Bucket bucket, Component component) {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        final Asset asset = findAsset(bucket, component);
+        if (asset == null)
+            return null;
+
+        BlobRef blobref = asset.blobRef();
+        if (blobref == null)
+            return null;
+
+        final Blob blob = tx.requireBlob(blobref);
+        if (blob == null)
+            return null;
+
+        if (asset.markAsDownloaded()) {
+            tx.saveAsset(asset);
+        }
+
+        final String contentType = asset.contentType();
+        final Content content = new Content(new BlobPayload(blob, contentType));
+        Content.extractFromAsset(asset, HASH_ALGORITHMS, content.getAttributes());
+        return content;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/ComponentKindCrateAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/ComponentKindCrateAttributes.java
@@ -70,6 +70,18 @@ public class ComponentKindCrateAttributes
         return Iterables.getOnlyElement(components, null);
     }
 
+    @TransactionalTouchMetadata
+    public Iterable<Component> findAllVersions(Repository repository, String crateName) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        return tx.findComponents(
+                Query.builder()
+                        .where(ComponentEntityAdapter.P_GROUP).eq(I_GROUP_CRATE)
+                        .and(ComponentEntityAdapter.P_NAME).eq(crateName)
+                        .build(),
+                Collections.singletonList(repository));
+    }
+
     public CrateCoordinates getCoordinates(Component component) {
         return new CrateCoordinates(component.name(), new Semver(component.version()));
     }

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/ComponentKindCrateAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/ComponentKindCrateAttributes.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.registry.assets;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import javax.inject.Named;
+
+import com.google.common.collect.Iterables;
+import com.vdurmont.semver4j.Semver;
+
+import org.sonatype.nexus.plugins.cargo.CrateCoordinates;
+import org.sonatype.nexus.repository.Repository;
+import org.sonatype.nexus.repository.storage.Bucket;
+import org.sonatype.nexus.repository.storage.Component;
+import org.sonatype.nexus.repository.storage.ComponentEntityAdapter;
+import org.sonatype.nexus.repository.storage.Query;
+import org.sonatype.nexus.repository.storage.StorageTx;
+import org.sonatype.nexus.repository.transaction.TransactionalStoreMetadata;
+import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
+import org.sonatype.nexus.transaction.UnitOfWork;
+
+@Named
+public class ComponentKindCrateAttributes
+{
+    final private String I_GROUP_CRATE = "crates";
+
+    @TransactionalStoreMetadata
+    public Component create(Repository repository, CrateCoordinates coords) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+        Bucket bucket = tx.findBucket(repository);
+
+        // This could be the first time the bucket is referenced which means it
+        // doesn't actually exist in the database. Go ahead and save it to
+        // force the record to be populated.
+        tx.saveBucket(bucket);
+
+        Component component = tx.createComponent(bucket, repository.getFormat());
+        component.group(I_GROUP_CRATE);
+        component.name(coords.getName());
+        component.version(coords.getVersion().getValue());
+        tx.saveComponent(component);
+
+        return component;
+    }
+
+    @TransactionalTouchMetadata
+    public Component find(Repository repository, CrateCoordinates coords) throws IOException {
+        StorageTx tx = UnitOfWork.currentTx();
+
+        Iterable<Component> components =
+                tx.findComponents(
+                        Query.builder().where(ComponentEntityAdapter.P_GROUP).eq(I_GROUP_CRATE)
+                                .and(ComponentEntityAdapter.P_NAME).eq(coords.getName())
+                                .and(ComponentEntityAdapter.P_VERSION).eq(coords.getVersion().getValue()).build(),
+                        Collections.singletonList(repository));
+
+        return Iterables.getOnlyElement(components, null);
+    }
+
+    public CrateCoordinates getCoordinates(Component component) {
+        return new CrateCoordinates(component.name(), new Semver(component.version()));
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/v1/CargoRegistryV1Handlers.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/v1/CargoRegistryV1Handlers.java
@@ -15,19 +15,12 @@ package org.sonatype.nexus.plugins.cargo.registry.v1;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.google.common.base.Preconditions;
-import com.google.common.io.LittleEndianDataInputStream;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.vdurmont.semver4j.Semver;
-
-import org.apache.commons.io.input.BoundedInputStream;
 import org.sonatype.goodies.common.ComponentSupport;
 import org.sonatype.nexus.plugins.cargo.CargoRegistryFacet;
 import org.sonatype.nexus.plugins.cargo.CrateCoordinates;
@@ -43,7 +36,13 @@ import org.sonatype.nexus.repository.view.Response;
 import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
 import org.sonatype.nexus.security.SecuritySystem;
 
-import jline.internal.InputStreamReader;
+import com.google.common.base.Preconditions;
+import com.google.common.io.LittleEndianDataInputStream;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.vdurmont.semver4j.Semver;
+import org.apache.commons.io.input.BoundedInputStream;
 
 public final class CargoRegistryV1Handlers
 {

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/v1/CargoRegistryV1Handlers.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/v1/CargoRegistryV1Handlers.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.registry.v1;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.LittleEndianDataInputStream;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.vdurmont.semver4j.Semver;
+
+import org.apache.commons.io.input.BoundedInputStream;
+import org.sonatype.goodies.common.ComponentSupport;
+import org.sonatype.nexus.plugins.cargo.CargoRegistryFacet;
+import org.sonatype.nexus.plugins.cargo.CrateCoordinates;
+import org.sonatype.nexus.plugins.cargo.git.GitRepositoryHandlers;
+import org.sonatype.nexus.plugins.cargo.registry.assets.AssetKindMetadataAttributes;
+import org.sonatype.nexus.plugins.cargo.registry.assets.AssetKindTarballAttributes;
+import org.sonatype.nexus.plugins.cargo.registry.assets.ComponentKindCrateAttributes;
+import org.sonatype.nexus.repository.http.HttpResponses;
+import org.sonatype.nexus.repository.view.Content;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Handler;
+import org.sonatype.nexus.repository.view.Response;
+import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
+import org.sonatype.nexus.security.SecuritySystem;
+
+import jline.internal.InputStreamReader;
+
+public final class CargoRegistryV1Handlers
+{
+
+    private static abstract class CrateHandlerSupport
+            extends ComponentSupport
+            implements Handler
+    {
+        protected final ComponentKindCrateAttributes crateAttributes;
+
+        protected final AssetKindMetadataAttributes metadataAttributes;
+
+        protected final AssetKindTarballAttributes tarballAttributes;
+
+        @Inject
+        protected CrateHandlerSupport(ComponentKindCrateAttributes crateAttributes,
+                                      AssetKindMetadataAttributes metadataAttributes,
+                                      AssetKindTarballAttributes tarballAttributes)
+        {
+            this.crateAttributes = crateAttributes;
+            this.metadataAttributes = metadataAttributes;
+            this.tarballAttributes = tarballAttributes;
+        }
+    }
+
+    @Named
+    public static class Publish
+            extends CrateHandlerSupport
+    {
+
+        @Inject
+        public Publish(ComponentKindCrateAttributes crateAttributes,
+                       AssetKindMetadataAttributes metadataAttributes,
+                       AssetKindTarballAttributes tarballAttributes)
+        {
+            super(crateAttributes, metadataAttributes, tarballAttributes);
+        }
+
+        @Override
+        public Response handle(Context context) throws Exception {
+            CargoRegistryFacet cargoImpl = context.getRepository().facet(CargoRegistryFacet.class);
+
+            // Cargo sends a single-part body containing both metadata in JSON
+            // and the actual crate in a tarball. Each part is prefixed with a
+            // 32-bit little-endian length identifier. Split off the JSON and
+            // turn the tarball into a Blob as the former needs to be parsed
+            // before mapping onto an Asset while the latter is simply stored.
+            LittleEndianDataInputStream requestBody =
+                    new LittleEndianDataInputStream(context.getRequest().getPayload().openInputStream());
+            try {
+                int jsonLength = requestBody.readInt();
+                byte[] jsonBytes = new byte[jsonLength];
+                requestBody.readFully(jsonBytes);
+                int tarballLength = requestBody.readInt();
+                InputStream tarball = new BoundedInputStream(requestBody, tarballLength);
+
+                try {
+                    // Parse the metadata into a JSON object.
+                    JsonParser jsonParser = new JsonParser();
+                    JsonElement json = jsonParser.parse(new InputStreamReader(new ByteArrayInputStream(jsonBytes)));
+                    if (!json.isJsonObject()) {
+                        return HttpResponses.badRequest("Expected JSON portion to contain an object");
+                    }
+                    JsonObject publishRequest = json.getAsJsonObject();
+
+                    // Use the provided name and verison to construct an identifier.
+                    String crateName = publishRequest.get("name").getAsString();
+                    Semver crateVersion = new Semver(publishRequest.get("vers").getAsString());
+                    CrateCoordinates crateId = new CrateCoordinates(crateName, crateVersion);
+
+                    return cargoImpl.publishCrate(crateId, publishRequest, tarball);
+                }
+                finally {
+                    tarball.close();
+                }
+            }
+            finally {
+                requestBody.close();
+            }
+        }
+    };
+
+    /**
+     * Fetches the crate for a download request. Requires a TokenMatcher that provides the following
+     * tokens: - name: Name of the crate to download - version: Version of the crate to download
+     * Returns: HttpResponses.ok if the crate is found, HttpResponses.notFound otherwise.
+     */
+    @Named
+    public static class CrateDownload
+            extends CrateHandlerSupport
+    {
+        @Inject
+        public CrateDownload(ComponentKindCrateAttributes crateAttributes,
+                             AssetKindMetadataAttributes metadataAttributes,
+                             AssetKindTarballAttributes tarballAttributes)
+        {
+            super(crateAttributes, metadataAttributes, tarballAttributes);
+        }
+
+        @Override
+        public Response handle(@Nonnull final Context context) throws Exception {
+            TokenMatcher.State state = context.getAttributes().require(TokenMatcher.State.class);
+            String name = state.getTokens().get("name");
+            String version = state.getTokens().get("version");
+
+            Preconditions.checkNotNull(name, "Download handler called without a 'name' token");
+            Preconditions.checkNotNull(version, "Download handler called without a 'version' token");
+
+            CrateCoordinates coords = new CrateCoordinates(name, new Semver(version));
+            CargoRegistryFacet crates = context.getRepository().facet(CargoRegistryFacet.class);
+            Content content = crates.downloadTarball(coords);
+            if (content != null) {
+                return HttpResponses.ok(content);
+            }
+            else {
+                return HttpResponses.notFound("Crate '" + name + "-" + version + "' not found");
+            }
+        }
+    };
+
+    /**
+     * Fetches the metdata for a crate. Requires a TokenMatcher that provides the following tokens:
+     * - name: Name of the crate to download - version: Version of the crate to download Returns:
+     * HttpResponses.ok if the crate is found, HttpResponses.notFound otherwise.
+     */
+    @Named
+    public static class MetadataDownload
+            extends CrateHandlerSupport
+    {
+        @Inject
+        public MetadataDownload(ComponentKindCrateAttributes crateAttributes,
+                                AssetKindMetadataAttributes metadataAttributes,
+                                AssetKindTarballAttributes tarballAttributes)
+        {
+            super(crateAttributes, metadataAttributes, tarballAttributes);
+        }
+
+        @Override
+        public Response handle(@Nonnull final Context context) throws Exception {
+            TokenMatcher.State state = context.getAttributes().require(TokenMatcher.State.class);
+            String name = state.getTokens().get("name");
+            String version = state.getTokens().get("version");
+
+            Preconditions.checkNotNull(name, "Download handler called without a 'name' token");
+            Preconditions.checkNotNull(version, "Download handler called without a 'version' token");
+
+            CrateCoordinates coords = new CrateCoordinates(name, new Semver(version));
+            CargoRegistryFacet crates = context.getRepository().facet(CargoRegistryFacet.class);
+            Content content = crates.downloadMetadata(coords);
+            if (content != null) {
+                return HttpResponses.ok(content);
+            }
+            else {
+                return HttpResponses.notFound("Crate '" + name + "-" + version + "' not found");
+            }
+        }
+    };
+
+    @Named
+    public static class IndexInfoRefs
+            extends GitRepositoryHandlers.InfoRefs
+    {
+        @Override
+        public Response handle(Context context) throws Exception {
+            context.getRepository().facet(CargoRegistryFacet.class).writeConfigJson();
+            return super.handle(context);
+        }
+    }
+
+    @Named
+    public static class IndexRecievePackService
+            extends GitRepositoryHandlers.ReceivePackService
+    {
+        @Inject
+        public IndexRecievePackService(SecuritySystem security) {
+            super(security);
+        }
+
+        @Override
+        public Response handle(Context context) throws Exception {
+            context.getRepository().facet(CargoRegistryFacet.class).writeConfigJson();
+            return super.handle(context);
+        }
+    }
+
+    @Named
+    public static class IndexUploadPackService
+            extends GitRepositoryHandlers.UploadPackService
+    {
+        @Override
+        public Response handle(Context context) throws Exception {
+            context.getRepository().facet(CargoRegistryFacet.class).writeConfigJson();
+            return super.handle(context);
+        }
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoFormatSecurityContributor.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoFormatSecurityContributor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.security;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.plugins.cargo.CargoFormat;
+import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
+
+/**
+ * Cargo format security resource.
+ */
+@Named
+@Singleton
+public class CargoFormatSecurityContributor
+        extends RepositoryFormatSecurityContributor
+{
+    @Inject
+    public CargoFormatSecurityContributor(@Named(CargoFormat.NAME) final Format format) {
+        super(format);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoRegistryBearerTokenHandlers.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoRegistryBearerTokenHandlers.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.security;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import org.apache.http.entity.ContentType;
+import org.apache.shiro.authz.AuthorizationException;
+import org.sonatype.nexus.repository.http.HttpResponses;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Handler;
+import org.sonatype.nexus.repository.view.Payload;
+import org.sonatype.nexus.repository.view.Response;
+import org.sonatype.nexus.repository.view.payloads.StringPayload;
+import org.sonatype.nexus.security.SecurityHelper;
+
+public class CargoRegistryBearerTokenHandlers
+{
+    @Named
+    public static class Get
+            implements Handler
+    {
+        private final SecurityHelper securityHelper;
+
+        private final CargoRegistryBearerTokenManager tokenManager;
+
+        @Inject
+        Get(CargoRegistryBearerTokenManager tokenManager, SecurityHelper securityHelper) {
+            this.securityHelper = securityHelper;
+            this.tokenManager = tokenManager;
+        }
+
+        @Override
+        public Response handle(Context context) throws Exception {
+            if (!this.securityHelper.subject().isAuthenticated()) {
+                throw new AuthorizationException("Must be authenticated to obtain an API token");
+            }
+
+            // Clients should provide a JSON request that includes a name for
+            // the new token. As Nexus BearerTokens only allow one token per
+            // format, just ignore the requested name and return the "Default
+            // Token".
+
+            String token = this.tokenManager.getTokenForCurrentUser();
+            Payload payload =
+                    new StringPayload("Bearer " + token, StandardCharsets.UTF_8, ContentType.TEXT_PLAIN.getMimeType());
+            return HttpResponses.ok(payload);
+        }
+    }
+
+    @Named
+    public static class Delete
+            implements Handler
+    {
+        private final CargoRegistryBearerTokenManager tokenManager;
+
+        @Inject
+        Delete(CargoRegistryBearerTokenManager tokenManager) {
+            this.tokenManager = tokenManager;
+        }
+
+        @Override
+        public Response handle(Context context) throws Exception {
+            this.tokenManager.deleteToken();
+            return HttpResponses.ok(new Gson().toJson(new JsonObject()));
+        }
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoRegistryBearerTokenManager.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoRegistryBearerTokenManager.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.security;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.plugins.cargo.CargoRegistryBearerToken;
+import org.sonatype.nexus.security.SecurityHelper;
+import org.sonatype.nexus.security.authc.apikey.ApiKeyStore;
+import org.sonatype.nexus.security.token.BearerTokenManager;
+
+@Named
+@Singleton
+public class CargoRegistryBearerTokenManager
+        extends BearerTokenManager
+{
+    @Inject
+    public CargoRegistryBearerTokenManager(final ApiKeyStore apiKeyStore, final SecurityHelper securityHelper) {
+        super(apiKeyStore, securityHelper, CargoRegistryBearerToken.NAME);
+    };
+
+    public String getTokenForCurrentUser() {
+        log.debug("Creating cargo token for subject: {}", this.securityHelper.subject().toString());
+        return super.createToken(this.securityHelper.subject().getPrincipals());
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoRegistryBearerTokenRealm.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoRegistryBearerTokenRealm.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.security;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.sisu.Description;
+import org.sonatype.nexus.plugins.cargo.CargoRegistryBearerToken;
+import org.sonatype.nexus.security.UserPrincipalsHelper;
+import org.sonatype.nexus.security.authc.apikey.ApiKeyStore;
+import org.sonatype.nexus.security.token.BearerTokenRealm;
+
+@Named(CargoRegistryBearerToken.NAME)
+@Singleton
+@Description("Cargo Registry Bearer Token Realm")
+public final class CargoRegistryBearerTokenRealm
+        extends BearerTokenRealm
+{
+    @Inject
+    public CargoRegistryBearerTokenRealm(final ApiKeyStore keyStore, final UserPrincipalsHelper principalsHelper) {
+        super(keyStore, principalsHelper, CargoRegistryBearerToken.NAME);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoSecurityFacet.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoSecurityFacet.java
@@ -17,9 +17,12 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.http.HttpMethods;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.SecurityFacetSupport;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+import org.sonatype.nexus.repository.view.Request;
+import org.sonatype.nexus.security.BreadActions;
 
 /**
  * Cargo format security facet.
@@ -36,8 +39,29 @@ public class CargoSecurityFacet
         super(securityResource, variableResolverAdapter, contentPermissionChecker);
     }
 
+    // This needs to exist so that Configuration is imported correctly. The
+    // bundle will fail to load due to Guice being unable to find the class otherwise.
     @Override
-    protected void doValidate(final Configuration configuration) throws Exception {
+    protected void doValidate(Configuration configuration) throws Exception {
         super.doValidate(configuration);
+    }
+
+    @Override
+    protected String action(Request request) {
+        if (request.getAction().equals(HttpMethods.POST) &&
+                request.getPath().equals("/index/git-upload-pack")) {
+            // Git Smart HTTP protocol uses a POST request for reading the repo so
+            // the client can set Git pack-format messages to indicate what objects
+            // it wants.
+            return BreadActions.READ;
+        } else if (request.getAction().equals(HttpMethods.POST) &&
+                request.getPath().equals("/index/git-receive-pack")) {
+            // Normally, the index will only be written to by Nexus. If a user
+            // has edit permissions, let them commit arbitrary things to the
+            // index anyway.
+            return BreadActions.EDIT;
+        } else {
+            return super.action(request);
+        }
     }
 }

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoSecurityFacet.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/security/CargoSecurityFacet.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.security;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.security.ContentPermissionChecker;
+import org.sonatype.nexus.repository.security.SecurityFacetSupport;
+import org.sonatype.nexus.repository.security.VariableResolverAdapter;
+
+/**
+ * Cargo format security facet.
+ */
+@Named
+public class CargoSecurityFacet
+        extends SecurityFacetSupport
+{
+    @Inject
+    public CargoSecurityFacet(final CargoFormatSecurityContributor securityResource,
+                              @Named("simple") final VariableResolverAdapter variableResolverAdapter,
+                              final ContentPermissionChecker contentPermissionChecker)
+    {
+        super(securityResource, variableResolverAdapter, contentPermissionChecker);
+    }
+
+    @Override
+    protected void doValidate(final Configuration configuration) throws Exception {
+        super.doValidate(configuration);
+    }
+}

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/ui/UiPluginDescriptorImpl.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/ui/UiPluginDescriptorImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+package org.sonatype.nexus.plugins.cargo.ui;
+
+import javax.annotation.Priority;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.sonatype.nexus.rapture.UiPluginDescriptorSupport;
+
+@Named
+@Singleton
+@Priority(Integer.MAX_VALUE - 200)
+public class UiPluginDescriptorImpl
+        extends UiPluginDescriptorSupport
+{
+    public UiPluginDescriptorImpl() {
+        super("nexus-repository-cargo");
+        setNamespace("NX.cargo");
+        setConfigClassName("NX.cargo.app.PluginConfig");
+    }
+}

--- a/src/main/resources/static/rapture/NX/cargo/app/PluginConfig.js
+++ b/src/main/resources/static/rapture/NX/cargo/app/PluginConfig.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+ Ext.define('NX.cargo.app.PluginConfig', {
+    '@aggregate_priority': 100,
+
+    requires: [
+        'NX.cargo.app.PluginStrings',
+        'NX.cargo.util.CargoRepositoryUrls'
+    ]
+});

--- a/src/main/resources/static/rapture/NX/cargo/app/PluginStrings.js
+++ b/src/main/resources/static/rapture/NX/cargo/app/PluginStrings.js
@@ -23,7 +23,9 @@ Ext.define('NX.cargo.app.PluginStrings', {
     ],
 
     keys: {
-        Repository_Facet_CargoFacet_Title: 'Cargo Settings',
+        Repository_Facet_CargoRegistryFacet_Title: 'Cargo Settings',
+        Repository_Facet_CargoRegistryFacet_AllowedRegistries_FieldLabel: 'Allowed External Registries',
+        Repository_Facet_CargoRegistryFacet_AllowedRegistries_HelpText: '',
         SearchCargo_Group: 'Cargo Repositories',
         SearchCargo_License_FieldLabel: 'License',
         SearchCargo_Text: 'Cargo',

--- a/src/main/resources/static/rapture/NX/cargo/app/PluginStrings.js
+++ b/src/main/resources/static/rapture/NX/cargo/app/PluginStrings.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+/*
+ * Cargo plugin strings.
+ */
+Ext.define('NX.cargo.app.PluginStrings', {
+    '@aggregate_priority': 90,
+
+    singleton: true,
+    requires: [
+        'NX.I18n'
+    ],
+
+    keys: {
+        Repository_Facet_CargoFacet_Title: 'Cargo Settings',
+        SearchCargo_Group: 'Cargo Repositories',
+        SearchCargo_License_FieldLabel: 'License',
+        SearchCargo_Text: 'Cargo',
+        SearchCargo_Description: 'Search for components in Cargo repositories',
+    }
+}, function (self) {
+    NX.I18n.register(self);
+});

--- a/src/main/resources/static/rapture/NX/cargo/util/CargoRepositoryUrls.js
+++ b/src/main/resources/static/rapture/NX/cargo/util/CargoRepositoryUrls.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+Ext.define('NX.cargo.util.CargoRepositoryUrls', {
+    '@aggregate_priority': 90,
+
+    singleton: true,
+    requires: [
+        'NX.coreui.util.RepositoryUrls',
+        'NX.util.Url'
+    ]
+}, function (self) {
+    NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('cargo', function (assetModel) {
+        var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
+        return NX.util.Url.asLink(NX.util.Url.baseUrl + '/repository/' + repositoryName + '/' + assetName, assetName);
+    });
+});

--- a/src/main/resources/static/rapture/NX/cargo/view/repository/facet/CargoRegistryFacet.js
+++ b/src/main/resources/static/rapture/NX/cargo/view/repository/facet/CargoRegistryFacet.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+/*
+ * Configuration specific to cargo repositories.
+ */
+Ext.define('NX.cargo.view.repository.facet.CargoRegistryFacet', {
+    extend: 'Ext.form.FieldContainer',
+    alias: 'widget.nx-cargo-repository-cargo-registry-facet',
+    requires: [
+        'NX.I18n'
+    ],
+    /**
+     * @override
+     */
+    initComponent: function () {
+        var me = this;
+
+        me.items = [
+            {
+                xtype: 'fieldset',
+                cls: 'nx-form-section',
+                title: NX.I18n.get('Repository_Facet_CargoRegistryFacet_Title'),
+                items: [
+                    {
+                        xtype: 'nx-url',
+                        name: 'attributes.cargo.allowedRegistries',
+                        itemId: "allowedRegistries",
+                        fieldLabel: NX.I18n.get('Repository_Facet_CargoRegistryFacet_AllowedRegistries_FieldLabel'),
+                        helpText: NX.I18n.get('Repository_Facet_CargoRegistryFacet_AllowedRegistries_HelpText'),
+                        emptyText: NX.I18n.get('Repository_Facet_CargoRegistryFacet_AllowedRegistries_EmptyText'),
+                        value: 'https://github.com/rust-lang/crates.io-index'
+                    }
+                ]
+            }
+        ];
+
+        me.callParent();
+    }
+
+});

--- a/src/main/resources/static/rapture/NX/cargo/view/repository/recipe/CargoHosted.js
+++ b/src/main/resources/static/rapture/NX/cargo/view/repository/recipe/CargoHosted.js
@@ -18,6 +18,7 @@ Ext.define('NX.cargo.view.repository.recipe.CargoHosted', {
     extend: 'NX.coreui.view.repository.RepositorySettingsForm',
     alias: 'widget.nx-coreui-repository-cargo-hosted',
     requires: [
+        'NX.cargo.view.repository.facet.CargoRegistryFacet',
         'NX.coreui.view.repository.facet.StorageFacet',
         'NX.coreui.view.repository.facet.StorageFacetHosted'
     ],
@@ -30,7 +31,8 @@ Ext.define('NX.cargo.view.repository.recipe.CargoHosted', {
 
         me.items = [
             { xtype: 'nx-coreui-repository-storage-facet' },
-            { xtype: 'nx-coreui-repository-storage-hosted-facet' }
+            { xtype: 'nx-coreui-repository-storage-hosted-facet' },
+            { xtype: 'nx-cargo-repository-cargo-registry-facet' }
         ];
 
         me.callParent();

--- a/src/main/resources/static/rapture/NX/cargo/view/repository/recipe/CargoHosted.js
+++ b/src/main/resources/static/rapture/NX/cargo/view/repository/recipe/CargoHosted.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019, Imperva, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License Version 1.0, which accompanies this
+ * distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Imperva, the Imperva logo, SecureSphere, Incapsula, CounterBreach,
+ * ThreatRadar, Camouflage, Attack Analytics, Prevoty and design are trademarks
+ * of Imperva, Inc. and its subsidiaries. All other brand or product names are
+ * trademarks or registered trademarks of their respective holders.
+ */
+
+/*
+ * Repository settings form for a Cargo repository
+ */
+Ext.define('NX.cargo.view.repository.recipe.CargoHosted', {
+    extend: 'NX.coreui.view.repository.RepositorySettingsForm',
+    alias: 'widget.nx-coreui-repository-cargo-hosted',
+    requires: [
+        'NX.coreui.view.repository.facet.StorageFacet',
+        'NX.coreui.view.repository.facet.StorageFacetHosted'
+    ],
+
+    /**
+     * @override
+     */
+    initComponent: function () {
+        var me = this;
+
+        me.items = [
+            { xtype: 'nx-coreui-repository-storage-facet' },
+            { xtype: 'nx-coreui-repository-storage-hosted-facet' }
+        ];
+
+        me.callParent();
+    }
+});

--- a/src/main/resources/static/rapture/resources/nexus-repository-cargo-debug.css
+++ b/src/main/resources/static/rapture/resources/nexus-repository-cargo-debug.css
@@ -1,0 +1,1 @@
+/* placeholder */


### PR DESCRIPTION
Implements the following major components necessary for a crates.io-style registry that interoperates with cargo:
* Bearer token authentication
* Git repository (including Smart HTTP protocol) stored inside a Nexus repository
* Crate asset kinds
* Hosted repository supporting 'cargo publish'

Pieces missing for 'cargo fetch':
* Generation of index entries from crate metadata

Other rough edges:
* Repository settings UI for allowed registries should represent a list instead of a string
* No unit tests
* Git storage could be more efficient if packs were stored directly instead of decomposing into individual commits
* Repository browse UI shows Git objects instead of logical tree view of repository