### PR TITLE
Upgrade plugin to work with latest Nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The table below outlines what version of Nexus Repository the plugin was built a
 | v0.0.1         | 3.12.0-01                |
 | v0.0.1         | 3.29.2-02                |
 | v0.0.2         | 3.30.1-01                |
+| v0.0.3         | 3.30.1-01                |
+| v0.0.4         | 3.36.0-01                |
 
 If a new version of Nexus Repository is released and the plugin needs changes, a new release will be made, and this
 table will be updated to indicate which version of Nexus Repository it will function against. This is done on a time 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.30.1-01</version>
+    <version>3.36.0-01</version>
   </parent>
 
   <artifactId>nexus-repository-cargo</artifactId>

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindObjectAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/git/assets/AssetKindObjectAttributes.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.inject.Named;
 
-import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
 
 import org.eclipse.jgit.lib.AbbreviatedObjectId;
@@ -88,7 +87,7 @@ public class AssetKindObjectAttributes
         // Create a blob from the contents of the InputStream. This will be a
         // unique blob but the object ID may already exist. The blob will be
         // thrown away if it isn't attached to an Asset.
-        AssetBlob assetBlob = tx.createBlob("git-object", Suppliers.ofInstance(contents), hashes, null,
+        AssetBlob assetBlob = tx.createBlob("git-object", () -> contents, hashes, null,
                 CONTENT_TYPE_LOOSE_OBJECT, true);
 
         // If the calculated ObjectId is already saved in the object database,

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindMetadataAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindMetadataAttributes.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
 
 import org.sonatype.nexus.blobstore.api.Blob;
@@ -78,7 +77,7 @@ public class AssetKindMetadataAttributes
         String filename = crateAttributes.getCoordinates(component).getFileBasename() + ".json";
         asset.name(filename);
         asset.attributes().set(AssetEntityAdapter.P_ASSET_KIND, AssetKind.METADATA.name());
-        tx.setBlob(asset, filename, Suppliers.ofInstance(metadata), HASH_ALGORITHMS, null, CONTENT_TYPE_JSON, true);
+        tx.setBlob(asset, filename, () -> metadata, HASH_ALGORITHMS, null, CONTENT_TYPE_JSON, true);
         tx.saveAsset(asset);
 
         return asset;

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindTarballAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindTarballAttributes.java
@@ -20,7 +20,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -83,8 +82,7 @@ public class AssetKindTarballAttributes
         String tarballName = crateAttributes.getCoordinates(component).getFileBasename() + ".crate";
         asset.name(tarballName);
         asset.attributes().set(AssetEntityAdapter.P_ASSET_KIND, AssetKind.TARBALL.name());
-        tx.setBlob(asset, tarballName, Suppliers.ofInstance(tarball), HASH_ALGORITHMS, null, CONTENT_TYPE_TARBALL,
-                true);
+        tx.setBlob(asset, tarballName, () -> tarball, HASH_ALGORITHMS, null, CONTENT_TYPE_TARBALL, true);
         tx.saveAsset(asset);
 
         return asset;


### PR DESCRIPTION
Update the usage of `Supplier<InputStream>` to `InputStreamSupplier`, the more recent API that Nexus expects plugin authors to use.

This pull request makes the following changes:
* Bump version of `org.sonatype.nexus.plugins:nexus-plugins`
* Use `InputStreamSupplier` instead of `Supplier<InputStream>` (anonymous lambdas as this interface has a single method).