### PR TITLE
Switch to JAR-based deployment for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ FROM maven:3-jdk-8-alpine AS build
 
 COPY . /nexus-repository-cargo/
 RUN cd /nexus-repository-cargo/; \
-    mvn clean package -PbuildKar;
+    mvn clean package;
 
 FROM sonatype/nexus3:$NEXUS_VERSION
 
 ARG DEPLOY_DIR=/opt/sonatype/nexus/deploy/
 USER root
-COPY --from=build /nexus-repository-cargo/target/nexus-repository-cargo-*-bundle.kar ${DEPLOY_DIR}
+COPY --from=build /nexus-repository-cargo/target/nexus-repository-cargo-*.jar ${DEPLOY_DIR}
 USER nexus


### PR DESCRIPTION
This pull request makes the following changes:
* compile and put JAR instead of Karaf module for Docker image

It relates to the following issue #s:
* Fixes #14
