### PR TITLE
Index generation for Cargo repositories

### DIFF
--- a/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRegistryFacet.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/CargoRegistryFacet.java
@@ -29,6 +29,8 @@ public interface CargoRegistryFacet
 {
     public void writeConfigJson() throws Exception;
 
+    public void rebuildIndexForCrate(CrateCoordinates crateId) throws IOException;
+
     public Response publishCrate(CrateCoordinates crateId,
                                  JsonElement metadata,
                                  InputStream tarball) throws IOException;

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindTarballAttributes.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/assets/AssetKindTarballAttributes.java
@@ -47,7 +47,7 @@ public class AssetKindTarballAttributes
 {
     public static final String CONTENT_TYPE_TARBALL = "application/x-tar";
 
-    public static final List<HashAlgorithm> HASH_ALGORITHMS = Lists.newArrayList(HashAlgorithm.SHA1);
+    public static final List<HashAlgorithm> HASH_ALGORITHMS = Lists.newArrayList(HashAlgorithm.SHA1, HashAlgorithm.SHA256);
 
     protected final BucketEntityAdapter bucketEntityAdapter;
 

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/registry/v1/CargoRegistryV1Handlers.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/registry/v1/CargoRegistryV1Handlers.java
@@ -113,7 +113,11 @@ public final class CargoRegistryV1Handlers
                     Semver crateVersion = new Semver(publishRequest.get("vers").getAsString());
                     CrateCoordinates crateId = new CrateCoordinates(crateName, crateVersion);
 
-                    return cargoImpl.publishCrate(crateId, publishRequest, tarball);
+                    Response response = cargoImpl.publishCrate(crateId, publishRequest, tarball);
+                    if (response.getStatus().isSuccessful()) {
+                        cargoImpl.rebuildIndexForCrate(crateId);
+                    }
+                    return response;
                 }
                 finally {
                     tarball.close();


### PR DESCRIPTION
This pull request makes the following changes:
* implement Cargo index generation based on the work in [`index_generation`](https://github.com/sonatype-nexus-community/nexus-repository-cargo/tree/index_generation) branch

It relates to the following issue #s:
* Fixes #11
* Fixes #12

Co-authored-by: Max Vorobev <vmax0770@gmail.com>
My changes include:
* rebasing atop of latest `master`
* fixing the index format to be what Cargo expects: reference is here https://github.com/rust-lang/cargo/issues/4497
* automatically rebuilding crate index on upload