### PR TITLE
bugfix: add /me route for cargo login command

### DIFF
--- a/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
@@ -116,6 +116,12 @@ class CargoHostedRecipe
 
         // Crates.io API v1
         builder.route(new Route.Builder()
+                .matcher(LogicMatchers.and(new ActionMatcher(HttpMethods.GET), new LiteralMatcher("/me")))
+                .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
+                .handler(conditionalRequestHandler).handler(partialFetchHandler).handler(contentHeadersHandler)
+                .handler(unitOfWorkHandler).handler(tokenGetHandler).create());
+
+        builder.route(new Route.Builder()
                 .matcher(LogicMatchers.and(new ActionMatcher(HttpMethods.GET), new LiteralMatcher("/token")))
                 .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
                 .handler(conditionalRequestHandler).handler(partialFetchHandler).handler(contentHeadersHandler)


### PR DESCRIPTION
when configuring repository authentication, the `cargo login`  command ask to go to `https://<server>/<repository>/me` URL to retrieve token. This route was not handled

This pull request makes the following changes:
* add /me route for cargo login command