### PR TITLE
bugfix: better handling of semver versions in paths, to allow suffixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.vdurmont</groupId>
       <artifactId>semver4j</artifactId>
-      <version>2.2.0</version>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>

--- a/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
+++ b/src/main/java/org/sonatype/nexus/plugins/cargo/hosted/CargoHostedRecipe.java
@@ -136,21 +136,21 @@ class CargoHostedRecipe
 
         builder.route(new Route.Builder()
                 .matcher(LogicMatchers.and(new ActionMatcher(HttpMethods.HEAD, HttpMethods.GET),
-                        new TokenMatcher("/api/v1/crates/{name:.+}/{version:.+}/download")))
+                        new TokenMatcher("/api/v1/crates/{name:.+}/{version:[0-9].*}/download")))
                 .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
                 .handler(conditionalRequestHandler).handler(partialFetchHandler).handler(contentHeadersHandler)
                 .handler(unitOfWorkHandler).handler(crateDownloadHandler).create());
 
         builder.route(new Route.Builder()
                 .matcher(LogicMatchers.and(new ActionMatcher(HttpMethods.HEAD, HttpMethods.GET),
-                        new TokenMatcher("/{name:.+}-{version:.+}.crate")))
+                        new TokenMatcher("/{name:.+}-{version:[0-9].*}.crate")))
                 .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
                 .handler(conditionalRequestHandler).handler(partialFetchHandler).handler(contentHeadersHandler)
                 .handler(unitOfWorkHandler).handler(crateDownloadHandler).create());
 
         builder.route(new Route.Builder()
                 .matcher(LogicMatchers.and(new ActionMatcher(HttpMethods.HEAD, HttpMethods.GET),
-                        new TokenMatcher("/{name:.+}-{version:.+}.json")))
+                        new TokenMatcher("/{name:.+}-{version:[0-9].*}.json")))
                 .handler(timingHandler).handler(securityHandler).handler(exceptionHandler)
                 .handler(conditionalRequestHandler).handler(partialFetchHandler).handler(contentHeadersHandler)
                 .handler(unitOfWorkHandler).handler(metadataDownloadHandler).create());


### PR DESCRIPTION
Semver allow suffixes to version, like ` 1.2.3-beta` . With the actual route patterns, when downloading artefact, the version will be ` beta` only and not ` 1.2.3-beta` 

This pull request makes the following changes:
* change version patterns on routes
