### PR TITLE
bugfix: update CargoRepositoryUrls.js according to nexus

### DIFF
--- a/src/main/resources/static/rapture/NX/cargo/util/CargoRepositoryUrls.js
+++ b/src/main/resources/static/rapture/NX/cargo/util/CargoRepositoryUrls.js
@@ -20,8 +20,8 @@ Ext.define('NX.cargo.util.CargoRepositoryUrls', {
         'NX.util.Url'
     ]
 }, function (self) {
-    NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('cargo', function (assetModel) {
-        var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
+    NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('cargo', function (me, assetModel) {
+        var repositoryName = assetModel.get('repositoryName'), assetName = me.getAssetName(assetModel);
         return NX.util.Url.asLink(NX.util.Url.baseUrl + '/repository/' + repositoryName + '/' + assetName, assetName);
     });
 });


### PR DESCRIPTION
This pull request makes the following changes:

updating `RepositoryUrls.js` according to changes in nexus [commit](https://github.com/sonatype/nexus-public/blob/main/plugins/nexus-coreui-plugin/src/main/resources/static/rapture/NX/coreui/util/RepositoryUrls.js#L43) ,

* Fixes #29
